### PR TITLE
Replace `typed_builder` with `bon`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "locator"
-version = "2.1.0"
+version = "2.2.0"
 edition = "2021"
 
 [dependencies]
@@ -12,11 +12,12 @@ regex = "1.6.0"
 serde = { version = "1.0.140", features = ["derive"] }
 strum = { version = "0.24.1", features = ["derive"] }
 thiserror = "1.0.31"
-typed-builder = "0.10.0"
 utoipa = "4.2.3"
 serde_json = "1.0.95"
 documented = "0.4.1"
 semver = "1.0.23"
+bon = "2.3.0"
+duplicate = "2.0.0"
 
 [dev-dependencies]
 assert_matches = "1.5.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -259,6 +259,12 @@ impl From<&str> for Package {
     }
 }
 
+impl From<&Package> for Package {
+    fn from(value: &Package) -> Self {
+        value.clone()
+    }
+}
+
 impl std::fmt::Display for Package {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.0)
@@ -315,6 +321,12 @@ impl From<String> for Revision {
 impl From<&str> for Revision {
     fn from(value: &str) -> Self {
         Self::from(value.to_string())
+    }
+}
+
+impl From<&Revision> for Revision {
+    fn from(value: &Revision) -> Self {
+        value.clone()
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@
 
 use std::{borrow::Cow, str::FromStr};
 
+use duplicate::duplicate;
 use lazy_static::lazy_static;
 use regex::Regex;
 use serde::{Deserialize, Serialize};
@@ -178,27 +179,40 @@ pub enum Fetcher {
 #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
 pub struct OrgId(usize);
 
-impl From<OrgId> for u64 {
-    fn from(value: OrgId) -> Self {
-        value.0 as u64
-    }
-}
-
 impl From<OrgId> for usize {
     fn from(value: OrgId) -> Self {
         value.0
     }
 }
 
-impl From<OrgId> for i64 {
-    fn from(value: OrgId) -> Self {
-        value.0 as i64
+impl From<usize> for OrgId {
+    fn from(value: usize) -> Self {
+        Self(value)
     }
 }
 
-impl From<OrgId> for isize {
-    fn from(value: OrgId) -> Self {
-        value.0 as isize
+duplicate! {
+    [
+        number;
+        [ u64 ];
+        [ u32 ];
+        [ u16 ];
+        [ u8 ];
+        [ i64 ];
+        [ i32 ];
+        [ i16 ];
+        [ i8 ];
+        [ isize ];
+    ]
+    impl From<OrgId> for number {
+        fn from(value: OrgId) -> Self {
+            value.0 as number
+        }
+    }
+    impl From<number> for OrgId {
+        fn from(value: number) -> Self {
+            Self(value as usize)
+        }
     }
 }
 

--- a/src/locator.rs
+++ b/src/locator.rs
@@ -410,6 +410,35 @@ mod tests {
     use super::*;
 
     #[test]
+    fn optional_fields() {
+        let with_options = Locator::builder()
+            .fetcher(Fetcher::Git)
+            .package("github.com/foo/bar")
+            .maybe_org_id(Some(1234))
+            .maybe_revision(Some("abcd"))
+            .build();
+        let expected = Locator::builder()
+            .fetcher(Fetcher::Git)
+            .package("github.com/foo/bar")
+            .org_id(1234)
+            .revision("abcd")
+            .build();
+        assert_eq!(expected, with_options);
+
+        let without_options = Locator::builder()
+            .fetcher(Fetcher::Git)
+            .package("github.com/foo/bar")
+            .maybe_org_id(None::<usize>)
+            .maybe_revision(None::<&str>)
+            .build();
+        let expected = Locator::builder()
+            .fetcher(Fetcher::Git)
+            .package("github.com/foo/bar")
+            .build();
+        assert_eq!(expected, without_options);
+    }
+
+    #[test]
     fn trait_impls() {
         const_assert!(impls!(Locator: AsRef<Locator>));
         const_assert!(impls!(Locator: FromStr));

--- a/src/locator.rs
+++ b/src/locator.rs
@@ -410,6 +410,18 @@ mod tests {
     use super::*;
 
     #[test]
+    fn from_existing() {
+        let first = locator!(Git, "github.com/foo/bar");
+        let second = Locator::builder()
+            .fetcher(first.fetcher())
+            .maybe_org_id(first.org_id())
+            .package(first.package())
+            .maybe_revision(first.revision().as_ref())
+            .build();
+        assert_eq!(first, second);
+    }
+
+    #[test]
     fn optional_fields() {
         let with_options = Locator::builder()
             .fetcher(Fetcher::Git)

--- a/src/locator.rs
+++ b/src/locator.rs
@@ -1,12 +1,12 @@
 use std::{fmt::Display, str::FromStr};
 
+use bon::Builder;
 use documented::Documented;
 use getset::{CopyGetters, Getters};
 use lazy_static::lazy_static;
 use regex::Regex;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
-use typed_builder::TypedBuilder;
 use utoipa::{
     openapi::{ObjectBuilder, SchemaType},
     ToSchema,
@@ -115,17 +115,7 @@ macro_rules! locator {
 ///
 /// This parse function is based on the function used in FOSSA Core for maximal compatibility.
 #[derive(
-    Clone,
-    Eq,
-    PartialEq,
-    Ord,
-    PartialOrd,
-    Hash,
-    Debug,
-    TypedBuilder,
-    Getters,
-    CopyGetters,
-    Documented,
+    Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Builder, Getters, CopyGetters, Documented,
 )]
 pub struct Locator {
     /// Determines which fetcher is used to download this package.
@@ -150,7 +140,7 @@ pub struct Locator {
     /// - A private Maven package that is hosted on a private host is namespaced.
     /// - A public NPM package that is hosted on NPM is not namespaced.
     /// - A private NPM package that is hosted on NPM but requires credentials is namespaced.
-    #[builder(default, setter(transform = |id: usize| Some(OrgId(id))))]
+    #[builder(into)]
     #[getset(get_copy = "pub")]
     org_id: Option<OrgId>,
 
@@ -158,7 +148,7 @@ pub struct Locator {
     ///
     /// For example, the `git` fetcher fetching a github package
     /// uses a value in the form of `{user_name}/{package_name}`.
-    #[builder(setter(transform = |package: impl ToString| Package(package.to_string())))]
+    #[builder(into)]
     #[getset(get = "pub")]
     package: Package,
 
@@ -167,7 +157,7 @@ pub struct Locator {
     /// For example, the `git` fetcher fetching a github package
     /// uses a value in the form of `{git_sha}` or `{git_tag}`,
     /// and the fetcher disambiguates.
-    #[builder(default, setter(transform = |revision: impl ToString| Some(Revision::from(revision.to_string()))))]
+    #[builder(into)]
     #[getset(get = "pub")]
     revision: Option<Revision>,
 }

--- a/src/locator_package.rs
+++ b/src/locator_package.rs
@@ -267,6 +267,17 @@ mod tests {
     use super::*;
 
     #[test]
+    fn from_existing() {
+        let first = package!(Git, "github.com/foo/bar");
+        let second = PackageLocator::builder()
+            .fetcher(first.fetcher())
+            .maybe_org_id(first.org_id())
+            .package(first.package())
+            .build();
+        assert_eq!(first, second);
+    }
+
+    #[test]
     fn optional_fields() {
         let with_options = PackageLocator::builder()
             .fetcher(Fetcher::Git)

--- a/src/locator_package.rs
+++ b/src/locator_package.rs
@@ -1,10 +1,10 @@
 use std::{fmt::Display, str::FromStr};
 
+use bon::Builder;
 use documented::Documented;
 use getset::{CopyGetters, Getters};
 use serde::{Deserialize, Serialize};
 use serde_json::json;
-use typed_builder::TypedBuilder;
 use utoipa::{
     openapi::{ObjectBuilder, SchemaType},
     ToSchema,
@@ -72,17 +72,7 @@ macro_rules! package {
 ///
 /// This implementation ignores the `revision` segment if it exists. If this is not preferred, use [`Locator`] instead.
 #[derive(
-    Clone,
-    Eq,
-    PartialEq,
-    Ord,
-    PartialOrd,
-    Hash,
-    Debug,
-    TypedBuilder,
-    Getters,
-    CopyGetters,
-    Documented,
+    Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Builder, Getters, CopyGetters, Documented,
 )]
 pub struct PackageLocator {
     /// Determines which fetcher is used to download this package.
@@ -107,7 +97,7 @@ pub struct PackageLocator {
     /// - A private Maven package that is hosted on a private host is namespaced.
     /// - A public NPM package that is hosted on NPM is not namespaced.
     /// - A private NPM package that is hosted on NPM but requires credentials is namespaced.
-    #[builder(default, setter(transform = |id: usize| Some(OrgId(id))))]
+    #[builder(into)]
     #[getset(get_copy = "pub")]
     org_id: Option<OrgId>,
 
@@ -115,7 +105,7 @@ pub struct PackageLocator {
     ///
     /// For example, the `git` fetcher fetching a github package
     /// uses a value in the form of `{user_name}/{package_name}`.
-    #[builder(setter(transform = |package: impl ToString| Package(package.to_string())))]
+    #[builder(into)]
     #[getset(get = "pub")]
     package: Package,
 }
@@ -147,7 +137,7 @@ impl PackageLocator {
         let locator = StrictLocator::builder()
             .fetcher(self.fetcher)
             .package(self.package)
-            .revision(revision);
+            .revision(revision.to_string());
 
         match self.org_id {
             None => locator.build(),

--- a/src/locator_package.rs
+++ b/src/locator_package.rs
@@ -267,6 +267,32 @@ mod tests {
     use super::*;
 
     #[test]
+    fn optional_fields() {
+        let with_options = PackageLocator::builder()
+            .fetcher(Fetcher::Git)
+            .package("github.com/foo/bar")
+            .maybe_org_id(Some(1234))
+            .build();
+        let expected = PackageLocator::builder()
+            .fetcher(Fetcher::Git)
+            .package("github.com/foo/bar")
+            .org_id(1234)
+            .build();
+        assert_eq!(expected, with_options);
+
+        let without_options = PackageLocator::builder()
+            .fetcher(Fetcher::Git)
+            .package("github.com/foo/bar")
+            .maybe_org_id(None::<usize>)
+            .build();
+        let expected = PackageLocator::builder()
+            .fetcher(Fetcher::Git)
+            .package("github.com/foo/bar")
+            .build();
+        assert_eq!(expected, without_options);
+    }
+
+    #[test]
     fn trait_impls() {
         const_assert!(impls!(PackageLocator: AsRef<PackageLocator>));
         const_assert!(impls!(PackageLocator: FromStr));

--- a/src/locator_strict.rs
+++ b/src/locator_strict.rs
@@ -1,10 +1,10 @@
 use std::{fmt::Display, str::FromStr};
 
+use bon::Builder;
 use documented::Documented;
 use getset::{CopyGetters, Getters};
 use serde::{Deserialize, Serialize};
 use serde_json::json;
-use typed_builder::TypedBuilder;
 use utoipa::{
     openapi::{ObjectBuilder, SchemaType},
     ToSchema,
@@ -72,17 +72,7 @@ macro_rules! strict {
 /// {fetcher}+{org_id}/{package}${revision}
 /// ```
 #[derive(
-    Clone,
-    Eq,
-    PartialEq,
-    Ord,
-    PartialOrd,
-    Hash,
-    Debug,
-    TypedBuilder,
-    Getters,
-    CopyGetters,
-    Documented,
+    Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Builder, Getters, CopyGetters, Documented,
 )]
 pub struct StrictLocator {
     /// Determines which fetcher is used to download this package.
@@ -107,7 +97,7 @@ pub struct StrictLocator {
     /// - A private Maven package that is hosted on a private host is namespaced.
     /// - A public NPM package that is hosted on NPM is not namespaced.
     /// - A private NPM package that is hosted on NPM but requires credentials is namespaced.
-    #[builder(default, setter(transform = |id: usize| Some(OrgId(id))))]
+    #[builder(into)]
     #[getset(get_copy = "pub")]
     org_id: Option<OrgId>,
 
@@ -115,7 +105,7 @@ pub struct StrictLocator {
     ///
     /// For example, the `git` fetcher fetching a github package
     /// uses a value in the form of `{user_name}/{package_name}`.
-    #[builder(setter(transform = |package: impl ToString| Package(package.to_string())))]
+    #[builder(into)]
     #[getset(get = "pub")]
     package: Package,
 
@@ -124,7 +114,7 @@ pub struct StrictLocator {
     /// For example, the `git` fetcher fetching a github package
     /// uses a value in the form of `{git_sha}` or `{git_tag}`,
     /// and the fetcher disambiguates.
-    #[builder(setter(transform = |revision: impl ToString| Revision::from(revision.to_string())))]
+    #[builder(into)]
     #[getset(get = "pub")]
     revision: Revision,
 }

--- a/src/locator_strict.rs
+++ b/src/locator_strict.rs
@@ -240,6 +240,18 @@ mod tests {
     use super::*;
 
     #[test]
+    fn from_existing() {
+        let first = strict!(Git, "github.com/foo/bar", "abcd");
+        let second = StrictLocator::builder()
+            .fetcher(first.fetcher())
+            .maybe_org_id(first.org_id())
+            .package(first.package())
+            .revision(first.revision())
+            .build();
+        assert_eq!(first, second);
+    }
+
+    #[test]
     fn optional_fields() {
         let with_options = StrictLocator::builder()
             .fetcher(Fetcher::Git)

--- a/src/locator_strict.rs
+++ b/src/locator_strict.rs
@@ -240,6 +240,36 @@ mod tests {
     use super::*;
 
     #[test]
+    fn optional_fields() {
+        let with_options = StrictLocator::builder()
+            .fetcher(Fetcher::Git)
+            .package("github.com/foo/bar")
+            .maybe_org_id(Some(1234))
+            .revision("abcd")
+            .build();
+        let expected = StrictLocator::builder()
+            .fetcher(Fetcher::Git)
+            .package("github.com/foo/bar")
+            .org_id(1234)
+            .revision("abcd")
+            .build();
+        assert_eq!(expected, with_options);
+
+        let without_options = StrictLocator::builder()
+            .fetcher(Fetcher::Git)
+            .package("github.com/foo/bar")
+            .maybe_org_id(None::<usize>)
+            .revision("abcd")
+            .build();
+        let expected = StrictLocator::builder()
+            .fetcher(Fetcher::Git)
+            .package("github.com/foo/bar")
+            .revision("abcd")
+            .build();
+        assert_eq!(expected, without_options);
+    }
+
+    #[test]
     fn trait_impls() {
         const_assert!(impls!(StrictLocator: AsRef<StrictLocator>));
         const_assert!(impls!(StrictLocator: FromStr));


### PR DESCRIPTION
# Overview

Replaces [`typed_builder`](https://docs.rs/typed-builder/latest/typed_builder/derive.TypedBuilder.html) with [`bon`](https://docs.rs/bon/latest/bon/).

Primarily this is because it's annoying to have to do this:
```rust
let org_id = Some(1234);
let locator = StrictLocator::builder()
    .fetcher(Fetcher::Git)
    .package("...")
    .revision("...");
let locator = match org_id {
    None => locator.build(),
    Some(org_id) => locator.org_id(org_id).build(),
};
```

With `bon`, we can do this instead:
```rust
let org_id = Some(1234);
let locator = StrictLocator::builder()
    .fetcher(Fetcher::Git)
    .package("...")
    .revision("...")
    .maybe_org_id(org_id)
    .build();
```

And we can still build when we know we have a field:
```rust
let locator = StrictLocator::builder()
    .fetcher(Fetcher::Git)
    .package("...")
    .revision("...")
    .org_id(1234)
    .build();
```

Bon also generally encourages cleaner patterns (e.g. by requiring `Into` implementations instead of custom setters), generates nicer error messages, and generates cleaner code.

## Acceptance criteria

Existing tests pass (demonstrating that this isn't a breaking change) and new functionality exists.

## Testing plan

Automated testing

## Metrics

None

## Risks

At worst this might be secretly breaking for some edge case type conversion, but that should be easy enough for callers to work around if that's the case.

## References

None

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
