### PR TITLE
add the CodeSentry fetcher

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,6 +61,11 @@ pub enum Fetcher {
     #[strum(serialize = "cargo")]
     Cargo,
 
+    /// Interacts with projects from CodeSentry
+    #[strum(serialize = "csbinary")]
+    #[serde(rename = "csbinary")]
+    CodeSentry,
+
     /// Interacts with Composer.
     #[strum(serialize = "comp")]
     Comp,


### PR DESCRIPTION
# Overview

In https://github.com/fossas/sparkle/pull/418 I am adding support for vulns from CodeSentry. This will create vuln matches with projects using the CodeSentry fetcher, so we need to add the CodeSentry fetcher to this library.

The CodeSentry fetcher has a fetcher string of `csbinary` in Core. Locators look like `csbinary+<vendor>/<name>$<revision`.

## Acceptance criteria

The CodeSentry fetcher exists in this libary

## Testing plan



## Metrics


## Risks


## References



## Checklist

- [ ] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
