### PR TITLE
Add the concept of constraints

### DIFF
--- a/.github/workflows/check-static.yml
+++ b/.github/workflows/check-static.yml
@@ -10,4 +10,4 @@ jobs:
     - uses: dtolnay/rust-toolchain@stable
 
     - run: cargo fmt --all -- --check
-    - run: cargo clippy --all-features --all --tests -- -D clippy::all
+    - run: cargo clippy --all-features --all --tests -- -D clippy::correctness

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ alphanumeric-sort = "1.5.3"
 getset = "0.1.2"
 pretty_assertions = "1.4.0"
 serde = { version = "1.0.140", features = ["derive"] }
-strum = { version = "0.24.1", features = ["derive"] }
+strum = { version = "0.27.1", features = ["derive"] }
 thiserror = "1.0.31"
 utoipa = "4.2.3"
 serde_json = "1.0.95"
@@ -27,6 +27,7 @@ derive-new = "0.7.0"
 assert_matches = "1.5.0"
 impls = "1.0.3"
 itertools = "0.10.5"
+pretty_assertions = "1.4.0"
 proptest = "1.0.0"
 simple_test_case = "1.2.0"
 static_assertions = "1.1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,6 @@ lazy-regex = { version = "3.3.0", features = ["regex"] }
 enum-assoc = "1.2.4"
 unicase = "2.8.1"
 lexical-sort = "0.3.1"
-tap = "1.0.1"
 derive-new = "0.7.0"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "locator"
-version = "2.3.0"
+version = "2.4.0"
 edition = "2024"
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,9 @@ semver = "1.0.23"
 bon = "2.3.0"
 duplicate = "2.0.0"
 lazy-regex = { version = "3.3.0", features = ["regex"] }
+enum-assoc = "1.2.4"
+unicase = "2.8.1"
+lexical-sort = "0.3.1"
 
 [dev-dependencies]
 assert_matches = "1.5.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "locator"
 version = "2.3.0"
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 alphanumeric-sort = "1.5.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,8 @@ lazy-regex = { version = "3.3.0", features = ["regex"] }
 enum-assoc = "1.2.4"
 unicase = "2.8.1"
 lexical-sort = "0.3.1"
+tap = "1.0.1"
+derive-new = "0.7.0"
 
 [dev-dependencies]
 assert_matches = "1.5.0"

--- a/src/constraint.rs
+++ b/src/constraint.rs
@@ -124,7 +124,7 @@ impl From<&Constraint> for Constraint {
 
 impl AsRef<Constraint> for Constraint {
     fn as_ref(&self) -> &Constraint {
-        &self
+        self
     }
 }
 
@@ -190,7 +190,7 @@ impl From<&Constraint> for Constraints {
 
 impl AsRef<Constraints> for Constraints {
     fn as_ref(&self) -> &Constraints {
-        &self
+        self
     }
 }
 

--- a/src/constraint.rs
+++ b/src/constraint.rs
@@ -9,6 +9,30 @@ use crate::{Fetcher, Revision};
 
 mod fallback;
 
+/// Construct a [`Constraint`], guaranteed to be valid at compile time.
+///
+/// ```
+/// # use locator::{Constraint, Revision, semver::Version};
+/// let constraint = locator::constraint!(Compatible => 1, 0, 0);
+/// let expected = Constraint::Compatible(Revision::Semver(Version::new(1, 0, 0)));
+/// assert_eq!(constraint, expected);
+///
+/// let constraint = locator::constraint!(Equal => "abcd1234");
+/// let expected = Constraint::Equal(Revision::Opaque(String::from("abcd1234")));
+/// assert_eq!(constraint, expected);
+/// ```
+#[macro_export]
+macro_rules! constraint {
+    ($variant:ident => $major:literal, $minor:literal, $patch:literal) => {
+        $crate::Constraint::$variant($crate::Revision::Semver($crate::semver::Version::new(
+            $major, $minor, $patch,
+        )))
+    };
+    ($variant:ident => $opaque:literal) => {
+        $crate::Constraint::$variant($crate::Revision::Opaque($opaque.into()))
+    };
+}
+
 /// Describes version constraints supported by this crate.
 ///
 /// Note that different fetchers may interpret these constraints in different ways-
@@ -54,43 +78,49 @@ mod fallback;
 #[schema(example = json!({ "kind": "equal", "value": "1.0.0"}))]
 #[serde(rename_all = "snake_case", tag = "kind", content = "value")]
 #[func(const fn revision(&self) -> &Revision)]
-#[new(into)]
 #[non_exhaustive]
 pub enum Constraint {
     /// The comparing revision must be compatible with the provided revision.
     /// Note that the exact semantics of this constraint depend on the fetcher.
-    #[strum(serialize = "~={0:?}")]
+    #[strum(to_string = "~={0:?}")]
     #[assoc(revision = &_0)]
+    #[new(into)]
     Compatible(Revision),
 
     /// The comparing revision must be exactly equal to the provided revision.
-    #[strum(serialize = "=={0:?}")]
+    #[strum(to_string = "=={0:?}")]
     #[assoc(revision = &_0)]
+    #[new(into)]
     Equal(Revision),
 
     /// The comparing revision must not be exactly equal to the provided revision.
-    #[strum(serialize = "!={0:?}")]
+    #[strum(to_string = "!={0:?}")]
     #[assoc(revision = &_0)]
+    #[new(into)]
     NotEqual(Revision),
 
     /// The comparing revision must be less than the provided revision.
-    #[strum(serialize = "<{0:?}")]
+    #[strum(to_string = "<{0:?}")]
     #[assoc(revision = &_0)]
+    #[new(into)]
     Less(Revision),
 
     /// The comparing revision must be less than or equal to the provided revision.
-    #[strum(serialize = "<={0:?}")]
+    #[strum(to_string = "<={0:?}")]
     #[assoc(revision = &_0)]
+    #[new(into)]
     LessOrEqual(Revision),
 
     /// The comparing revision must be greater than the provided revision.
-    #[strum(serialize = ">{0:?}")]
+    #[strum(to_string = ">{0:?}")]
     #[assoc(revision = &_0)]
+    #[new(into)]
     Greater(Revision),
 
     /// The comparing revision must be greater than or equal to the provided revision.
-    #[strum(serialize = ">={0:?}")]
+    #[strum(to_string = ">={0:?}")]
     #[assoc(revision = &_0)]
+    #[new(into)]
     GreaterOrEqual(Revision),
 }
 

--- a/src/constraint.rs
+++ b/src/constraint.rs
@@ -10,6 +10,8 @@ use utoipa::ToSchema;
 
 use crate::{CompareError, Error, Fetcher, Revision};
 
+mod fallback;
+
 /// Describes version constraints supported by this crate.
 ///
 /// Note that different fetchers may interpret these constraints in different ways-
@@ -111,7 +113,7 @@ impl Constraint {
             todo!()
         }
 
-        // Final fallback: if compare according to UTF8 rules.
+        // Final fallback: if compare according to unicode rules.
         match self {
             Constraint::Compatible(c) => UniCase::new(c.as_str()) == UniCase::new(rev.as_str()),
             _ => self.lexically_compare(rev),

--- a/src/constraint.rs
+++ b/src/constraint.rs
@@ -1,0 +1,195 @@
+use std::cmp::Ordering;
+
+use documented::Documented;
+use enum_assoc::Assoc;
+use lexical_sort::lexical_cmp;
+use serde::{Deserialize, Serialize};
+use strum::Display;
+use unicase::UniCase;
+use utoipa::ToSchema;
+
+use crate::{CompareError, Error, Fetcher, Revision};
+
+/// Describes version constraints supported by this crate.
+///
+/// Note that different fetchers may interpret these constraints in different ways-
+/// for example `compatible` isn't the same in Cargo as it is in Cabal.
+///
+/// # Serialization
+///
+/// The default serialization for this type is for transporting _this type_;
+/// it is not meant to support parsing the actual constraints in the native format
+/// used by the package manager.
+///
+/// # Comparison
+///
+/// Compares the [`Constraint`] to the given [`Revision`] according to the rules of the provided [`Fetcher`].
+///
+/// If there are no rules for that specific fetcher, the following fallbacks take place:
+/// - If both the `Constraint` and the `Revision` are parseable as semver, compare according to semver rules.
+/// - Otherwise, they are coerced to an opaque string and compared according to unicode ordering rules.
+///
+/// When comparing according to unicode:
+/// - `Equal` and `NotEqual` compare bytewise.
+/// - `Compatible` compares case insensitively, folding non-ASCII characters into their closest ASCII equivalent prior to comparing.
+/// - All other variants compare lexically, folding non-ASCII characters into their closest ASCII equivalent prior to comparing.
+///
+/// In practice this means that `Equal` and `NotEqual` are case-sensitive, while all other options are not;
+/// this case-insensitivity does its best to preserve the spirit of this intent in the face of non-ascii inputs.
+#[derive(
+    Debug,
+    Clone,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+    Deserialize,
+    Serialize,
+    Documented,
+    ToSchema,
+    Display,
+    Assoc,
+)]
+#[schema(example = json!("v1.0.0"))]
+#[serde(rename_all = "snake_case", tag = "kind", content = "value")]
+#[func(const fn revision(&self) -> &Revision)]
+#[non_exhaustive]
+pub enum Constraint {
+    /// The comparing revision must be compatible with the provided revision.
+    /// Note that the exact semantics of this constraint depend on the fetcher.
+    #[strum(serialize = "~={0:?}")]
+    #[assoc(revision = &_0)]
+    Compatible(Revision),
+
+    /// The comparing revision must be exactly equal to the provided revision.
+    #[strum(serialize = "=={0:?}")]
+    #[assoc(revision = &_0)]
+    Equal(Revision),
+
+    /// The comparing revision must not be exactly equal to the provided revision.
+    #[strum(serialize = "!={0:?}")]
+    #[assoc(revision = &_0)]
+    NotEqual(Revision),
+
+    /// The comparing revision must be less than the provided revision.
+    #[strum(serialize = "<{0:?}")]
+    #[assoc(revision = &_0)]
+    Less(Revision),
+
+    /// The comparing revision must be less than or equal to the provided revision.
+    #[strum(serialize = "<={0:?}")]
+    #[assoc(revision = &_0)]
+    LessOrEqual(Revision),
+
+    /// The comparing revision must be greater than the provided revision.
+    #[strum(serialize = ">{0:?}")]
+    #[assoc(revision = &_0)]
+    Greater(Revision),
+
+    /// The comparing revision must be greater than or equal to the provided revision.
+    #[strum(serialize = ">={0:?}")]
+    #[assoc(revision = &_0)]
+    GreaterOrEqual(Revision),
+}
+
+impl Constraint {
+    /// Compare the constraint to the given revision according to the rules of the provided fetcher.
+    /// The default if there are no additional rules specified for the fetcher is:
+    /// - If both versions are semver, compare according to semver rules.
+    /// - If not, coerce them both to an opaque string and compare according to unicode ordering rules.
+    ///
+    /// Inicode in this instance [`Constraint::Compatible`] is a case-insensitive equality comparison.
+    pub fn compare(&self, fetcher: Fetcher, rev: &Revision) -> bool {
+        // In the future we'll have a bunch of fetcher-specific comparisons here.
+        // match fetcher {
+        //     ...
+        // }
+
+        // Fallback: if they're both semver, compare according to semver rules.
+        if let (Revision::Semver(c), Revision::Semver(r)) = (self.revision(), rev) {
+            todo!()
+        }
+
+        // Final fallback: if compare according to UTF8 rules.
+        match self {
+            Constraint::Compatible(c) => UniCase::new(c.as_str()) == UniCase::new(rev.as_str()),
+            _ => self.lexically_compare(rev),
+        }
+    }
+
+    fn as_ords(&self) -> Vec<Ordering> {
+        match self {
+            Constraint::Compatible(_) => vec![Ordering::Equal],
+            Constraint::Equal(_) => vec![Ordering::Equal],
+            Constraint::NotEqual(_) => vec![Ordering::Less, Ordering::Greater],
+            Constraint::Less(_) => vec![Ordering::Less],
+            Constraint::LessOrEqual(_) => vec![Ordering::Less, Ordering::Equal],
+            Constraint::Greater(_) => vec![Ordering::Greater],
+            Constraint::GreaterOrEqual(_) => vec![Ordering::Greater, Ordering::Equal],
+        }
+    }
+
+    fn lexically_compare(&self, other: impl ToString) -> bool {
+        let constraint = self.revision().to_string();
+        let other = other.to_string();
+        for ord in self.as_ords() {
+            if lexical_sort::lexical_cmp(&constraint, &other) == ord {
+                return true;
+            }
+        }
+        return false;
+    }
+}
+
+impl From<&Constraint> for Constraint {
+    fn from(c: &Constraint) -> Self {
+        c.clone()
+    }
+}
+
+impl From<Constraint> for Revision {
+    fn from(c: Constraint) -> Self {
+        match c {
+            Constraint::Equal(r) => r,
+            Constraint::NotEqual(r) => r,
+            Constraint::Less(r) => r,
+            Constraint::LessOrEqual(r) => r,
+            Constraint::Greater(r) => r,
+            Constraint::GreaterOrEqual(r) => r,
+            Constraint::Compatible(r) => r,
+        }
+    }
+}
+
+impl From<&Constraint> for Revision {
+    fn from(c: &Constraint) -> Self {
+        c.clone().into()
+    }
+}
+
+/// A set of [`Constraint`].
+///
+/// This set forms an "AND" relationship between its constraints:
+/// it implements [`Constrainable::compare`] such that it indicates success
+/// only if all constraints are satisified.
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize, Documented, ToSchema)]
+#[non_exhaustive]
+pub struct Constraints(Vec<Constraint>);
+
+impl Constraints {
+    /// Iterate over constraints in the set.
+    pub fn iter(&self) -> impl Iterator<Item = &Constraint> {
+        self.0.iter()
+    }
+}
+
+impl<I, T> From<I> for Constraints
+where
+    I: IntoIterator<Item = T>,
+    T: Into<Constraint>,
+{
+    fn from(constraints: I) -> Self {
+        Self(constraints.into_iter().map(Into::into).collect())
+    }
+}

--- a/src/constraint/fallback.rs
+++ b/src/constraint/fallback.rs
@@ -1,8 +1,76 @@
+use std::cmp::Ordering;
+
+use semver::{Comparator, Op, Version, VersionReq};
+use tap::Pipe;
+use unicase::UniCase;
+
 use crate::{Fetcher, Revision};
 
 use super::Constraint;
 
-/// Fallback comparison when there is no fetcher-specific comparison
-pub fn compare(constraint: &Constraint, fetcher: Fetcher, rev: &Revision) -> bool {
-    todo!()
+/// Fallback comparison when there is no fetcher-specific comparison.
+///
+/// The default if there are no additional rules specified for the fetcher is:
+/// - If both versions are semver, compare according to semver rules.
+///   In this instance [`Constraint::Compatible`] is equivalent to a caret rule.
+/// - If not, coerce them both to an opaque string and compare according to unicode ordering rules.
+///   In this instance [`Constraint::Compatible`] is a case-insensitive equality comparison.
+pub fn compare(constraint: &Constraint, _: Fetcher, rev: &Revision) -> bool {
+    if let (Revision::Semver(c), Revision::Semver(r)) = (constraint.revision(), rev) {
+        return version_req_for(constraint, c).matches(r);
+    }
+
+    match constraint {
+        Constraint::Compatible(c) => UniCase::new(c.as_str()) == UniCase::new(rev.as_str()),
+        _ => lexically_compare(constraint, rev),
+    }
+}
+
+fn version_req_for(constraint: &Constraint, v: &Version) -> VersionReq {
+    match constraint {
+        Constraint::Compatible(_) => vec![Op::Tilde],
+        Constraint::Equal(_) => vec![Op::Exact],
+        Constraint::NotEqual(_) => vec![Op::Less, Op::Greater],
+        Constraint::Less(_) => vec![Op::Less],
+        Constraint::LessOrEqual(_) => vec![Op::LessEq],
+        Constraint::Greater(_) => vec![Op::Greater],
+        Constraint::GreaterOrEqual(_) => vec![Op::GreaterEq],
+    }
+    .into_iter()
+    .map(|op| comparator(op, v))
+    .collect::<Vec<_>>()
+    .pipe(|comparators| VersionReq { comparators })
+}
+
+fn comparator(op: Op, v: &Version) -> Comparator {
+    Comparator {
+        op,
+        major: v.major,
+        minor: Some(v.minor),
+        patch: Some(v.patch),
+        pre: v.pre.clone(),
+    }
+}
+
+fn ords_for(constraint: &Constraint) -> Vec<Ordering> {
+    match constraint {
+        Constraint::Compatible(_) => vec![Ordering::Equal],
+        Constraint::Equal(_) => vec![Ordering::Equal],
+        Constraint::NotEqual(_) => vec![Ordering::Less, Ordering::Greater],
+        Constraint::Less(_) => vec![Ordering::Less],
+        Constraint::LessOrEqual(_) => vec![Ordering::Less, Ordering::Equal],
+        Constraint::Greater(_) => vec![Ordering::Greater],
+        Constraint::GreaterOrEqual(_) => vec![Ordering::Greater, Ordering::Equal],
+    }
+}
+
+fn lexically_compare(constraint: &Constraint, other: impl ToString) -> bool {
+    let target = constraint.revision().to_string();
+    let other = other.to_string();
+    for ord in ords_for(constraint) {
+        if lexical_sort::lexical_cmp(&target, &other) == ord {
+            return true;
+        }
+    }
+    return false;
 }

--- a/src/constraint/fallback.rs
+++ b/src/constraint/fallback.rs
@@ -63,7 +63,7 @@ fn lexically_compare(constraint: &Constraint, other: impl ToString) -> bool {
             return true;
         }
     }
-    return false;
+    false
 }
 
 #[cfg(test)]

--- a/src/constraint/fallback.rs
+++ b/src/constraint/fallback.rs
@@ -1,7 +1,6 @@
 use std::cmp::Ordering;
 
-use semver::{Comparator, Op, Version, VersionReq};
-use tap::Pipe;
+use semver::{Comparator, Op, Version};
 use unicase::UniCase;
 
 use crate::{Fetcher, Revision};
@@ -17,29 +16,21 @@ use super::Constraint;
 ///   In this instance [`Constraint::Compatible`] is a case-insensitive equality comparison.
 pub fn compare(constraint: &Constraint, _: Fetcher, rev: &Revision) -> bool {
     if let (Revision::Semver(c), Revision::Semver(r)) = (constraint.revision(), rev) {
-        return version_req_for(constraint, c).matches(r);
+        return match constraint {
+            Constraint::Compatible(_) => comparator(Op::Tilde, c).matches(r),
+            Constraint::Equal(_) => comparator(Op::Exact, c).matches(r),
+            Constraint::NotEqual(_) => !comparator(Op::Exact, c).matches(r),
+            Constraint::Less(_) => comparator(Op::Less, c).matches(r),
+            Constraint::LessOrEqual(_) => comparator(Op::LessEq, c).matches(r),
+            Constraint::Greater(_) => comparator(Op::Greater, c).matches(r),
+            Constraint::GreaterOrEqual(_) => comparator(Op::GreaterEq, c).matches(r),
+        };
     }
 
     match constraint {
         Constraint::Compatible(c) => UniCase::new(c.as_str()) == UniCase::new(rev.as_str()),
         _ => lexically_compare(constraint, rev),
     }
-}
-
-fn version_req_for(constraint: &Constraint, v: &Version) -> VersionReq {
-    match constraint {
-        Constraint::Compatible(_) => vec![Op::Tilde],
-        Constraint::Equal(_) => vec![Op::Exact],
-        Constraint::NotEqual(_) => vec![Op::Less, Op::Greater],
-        Constraint::Less(_) => vec![Op::Less],
-        Constraint::LessOrEqual(_) => vec![Op::LessEq],
-        Constraint::Greater(_) => vec![Op::Greater],
-        Constraint::GreaterOrEqual(_) => vec![Op::GreaterEq],
-    }
-    .into_iter()
-    .map(|op| comparator(op, v))
-    .collect::<Vec<_>>()
-    .pipe(|comparators| VersionReq { comparators })
 }
 
 fn comparator(op: Op, v: &Version) -> Comparator {
@@ -73,4 +64,64 @@ fn lexically_compare(constraint: &Constraint, other: impl ToString) -> bool {
         }
     }
     return false;
+}
+
+#[cfg(test)]
+mod tests {
+    use simple_test_case::test_case;
+
+    use super::*;
+    use crate::{Revision, constraint};
+
+    // Using a fetcher that is unlikely to ever have actual comparison functionality.
+    const FETCHER: Fetcher = Fetcher::Archive;
+
+    #[test_case(constraint!(Compatible => 1, 2, 3), Revision::from("1.2.3"), true; "1.2.3_compatible_1.2.3")]
+    #[test_case(constraint!(Compatible => 1, 2, 3), Revision::from("1.2.4"), true; "1.2.4_compatible_1.2.3")]
+    #[test_case(constraint!(Compatible => 1, 2, 3), Revision::from("2.0.0"), false; "2.0.0_not_compatible_1.2.3")]
+    #[test_case(constraint!(Equal => 1, 2, 3), Revision::from("1.2.3"), true; "1.2.3_equal_1.2.3")]
+    #[test_case(constraint!(Equal => 1, 2, 3), Revision::from("1.2.4"), false; "1.2.4_not_equal_1.2.3")]
+    #[test_case(constraint!(NotEqual => 1, 2, 3), Revision::from("1.2.3"), false; "1.2.3_not_notequal_1.2.3")]
+    #[test_case(constraint!(NotEqual => 1, 2, 3), Revision::from("1.2.4"), true; "1.2.4_notequal_1.2.3")]
+    #[test_case(constraint!(Less => 1, 2, 3), Revision::from("1.2.2"), true; "1.2.2_less_1.2.3")]
+    #[test_case(constraint!(Less => 1, 2, 3), Revision::from("1.2.3"), false; "1.2.3_not_less_1.2.3")]
+    #[test_case(constraint!(LessOrEqual => 1, 2, 3), Revision::from("1.2.2"), true; "1.2.2_less_or_equal_1.2.3")]
+    #[test_case(constraint!(LessOrEqual => 1, 2, 3), Revision::from("1.2.3"), true; "1.2.3_less_or_equal_1.2.3")]
+    #[test_case(constraint!(LessOrEqual => 1, 2, 3), Revision::from("1.2.4"), false; "1.2.4_not_less_or_equal_1.2.3")]
+    #[test_case(constraint!(Greater => 1, 2, 3), Revision::from("1.2.4"), true; "1.2.4_greater_1.2.3")]
+    #[test_case(constraint!(Greater => 1, 2, 3), Revision::from("1.2.3"), false; "1.2.3_not_greater_1.2.3")]
+    #[test_case(constraint!(GreaterOrEqual => 1, 2, 3), Revision::from("1.2.4"), true; "1.2.4_greater_or_equal_1.2.3")]
+    #[test_case(constraint!(GreaterOrEqual => 1, 2, 3), Revision::from("1.2.3"), true; "1.2.3_greater_or_equal_1.2.3")]
+    #[test_case(constraint!(GreaterOrEqual => 1, 2, 3), Revision::from("1.2.2"), false; "1.2.2_not_greater_or_equal_1.2.3")]
+    #[test]
+    fn compare_semver(constraint: Constraint, target: Revision, expected: bool) {
+        assert_eq!(
+            compare(&constraint, FETCHER, &target),
+            expected,
+            "compare '{target}' to '{constraint}', expected: {expected}"
+        );
+    }
+
+    #[test_case(constraint!(Compatible => "abcd"), Revision::from("AbCd"), true; "abcd_compatible_AbCd")]
+    #[test_case(constraint!(Compatible => "abcd"), Revision::from("AbCdE"), false; "abcd_not_compatible_AbCdE")]
+    #[test_case(constraint!(Equal => "abcd"), Revision::from("abcd"), true; "abcd_equal_abcd")]
+    #[test_case(constraint!(Equal => "abcd"), Revision::from("aBcD"), false; "abcd_not_equal_aBcD")]
+    #[test_case(constraint!(NotEqual => "abcd"), Revision::from("abcde"), true; "abcd_notequal_abcde")]
+    #[test_case(constraint!(NotEqual => "abcd"), Revision::from("abcd"), false; "abcd_not_notequal_abcd")]
+    #[test_case(constraint!(Less => "a"), Revision::from("b"), true; "a_less_b")]
+    #[test_case(constraint!(Less => "a"), Revision::from("a"), false; "a_not_less_a")]
+    #[test_case(constraint!(Greater => "b"), Revision::from("a"), true; "b_greater_a")]
+    #[test_case(constraint!(Greater => "b"), Revision::from("c"), false; "b_not_greater_c")]
+    #[test_case(constraint!(Less => "あ"), Revision::from("え"), true; "jp_a_less_e")]
+    #[test_case(constraint!(Greater => "え"), Revision::from("あ"), true; "jp_e_greater_a")]
+    #[test_case(constraint!(Equal => "あ"), Revision::from("あ"), true; "jp_a_equal_a")]
+    #[test_case(constraint!(Compatible => "Maße"), Revision::from("MASSE"), true; "gr_masse_compatible_MASSE")]
+    #[test]
+    fn compare_opaque(constraint: Constraint, target: Revision, expected: bool) {
+        assert_eq!(
+            compare(&constraint, FETCHER, &target),
+            expected,
+            "compare '{target}' to '{constraint}', expected: {expected}"
+        );
+    }
 }

--- a/src/constraint/fallback.rs
+++ b/src/constraint/fallback.rs
@@ -1,0 +1,8 @@
+use crate::{Fetcher, Revision};
+
+use super::Constraint;
+
+/// Fallback comparison when there is no fetcher-specific comparison
+pub fn compare(constraint: &Constraint, fetcher: Fetcher, rev: &Revision) -> bool {
+    todo!()
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,7 +1,5 @@
 use thiserror::Error;
 
-use crate::{Fetcher, Revision, constraint::Constraint};
-
 /// Records all errors reported by this library.
 #[derive(Error, Clone, PartialEq, Eq, Debug)]
 #[non_exhaustive]
@@ -10,9 +8,9 @@ pub enum Error {
     #[error(transparent)]
     Parse(#[from] ParseError),
 
-    /// Errors encountered while comparing against a constraint.
+    /// Errors encountered while parsing a [`Constraint`](crate::Constraint).
     #[error(transparent)]
-    Compare(#[from] CompareError),
+    ParseConstraint(#[from] ConstraintParseError),
 }
 
 /// Errors encountered when parsing a [`Locator`](crate::Locator) from a string.
@@ -96,88 +94,9 @@ pub enum RevisionParseError {
     // No possible errors yet, but I'm sure there will be.
 }
 
-/// Errors encountered when comparing a [`Revision`](crate::Revision) against
-/// a [`Constraint`](crate::Constraint).
+/// Errors encountered when parsing a [`Constraint`](crate::Constraint) from a string.
 #[derive(Error, Clone, PartialEq, Eq, Debug)]
 #[non_exhaustive]
-pub enum CompareError {
-    /// The comparison is not supported.
-    #[error("unsupported: constrain {comparing:#?} to {constraint:#?} using fetcher '{fetcher}'")]
-    Unsupported {
-        /// The fetcher that was attempted to parse.
-        fetcher: Fetcher,
-
-        /// The revision being compared.
-        constraint: Constraint,
-
-        /// The revision being compared.
-        comparing: Revision,
-    },
-
-    /// Parsing the comparing revision according to the rules of the fetcher failed.
-    #[error("parse {comparing:#?} according to the rules of '{fetcher}': {source}")]
-    ParseComparing {
-        /// The fetcher that was attempted to parse.
-        fetcher: Fetcher,
-
-        /// The revision being compared.
-        comparing: Revision,
-
-        /// The cause of the error.
-        source: RevisionParseError,
-    },
-
-    /// Parsing the constraint revision according to the rules of the fetcher failed.
-    #[error("parse {constraint:#?} according to the rules of '{fetcher}': {source}")]
-    ParseConstraint {
-        /// The fetcher that was attempted to parse.
-        fetcher: Fetcher,
-
-        /// The revision being compared.
-        constraint: Constraint,
-
-        /// The cause of the error.
-        source: RevisionParseError,
-    },
-}
-
-impl CompareError {
-    /// Create a [`CompareError::Unsupported`] error.
-    pub fn unsupported(
-        fetcher: Fetcher,
-        constraint: impl Into<Constraint>,
-        comparing: impl Into<Revision>,
-    ) -> Self {
-        Self::Unsupported {
-            fetcher,
-            comparing: comparing.into(),
-            constraint: constraint.into(),
-        }
-    }
-
-    /// Create a [`CompareError::ParseComparing`] error.
-    pub fn parse_comparing(
-        fetcher: Fetcher,
-        comparing: impl Into<Revision>,
-        source: RevisionParseError,
-    ) -> Self {
-        Self::ParseComparing {
-            fetcher,
-            comparing: comparing.into(),
-            source,
-        }
-    }
-
-    /// Create a [`CompareError::ParseConstraint`] error.
-    pub fn parse_constraint(
-        fetcher: Fetcher,
-        constraint: impl Into<Constraint>,
-        source: RevisionParseError,
-    ) -> Self {
-        Self::ParseConstraint {
-            fetcher,
-            constraint: constraint.into(),
-            source,
-        }
-    }
+pub enum ConstraintParseError {
+    // No possible errors yet, but I'm sure there will be.
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -477,7 +477,7 @@ mod tests {
     #[test_case("1abc2/name", None, Package::new("1abc2/name"); "1abc2/name")]
     #[test_case("name/1234", None, Package::new("name/1234"); "name/1234")]
     #[test]
-    fn parse_org_package(input: &str, org: Option<OrgId>, package: Package) {
+    fn parses_org_package(input: &str, org: Option<OrgId>, package: Package) {
         let (org_id, name) = parse_org_package(input);
         assert_eq!(org_id, org, "'org_id' must match in '{input}'");
         assert_eq!(package, name, "'package' must match in '{input}");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,7 @@ use serde::{Deserialize, Serialize};
 use strum::{AsRefStr, Display, EnumIter, EnumString};
 use utoipa::ToSchema;
 
+mod constraint;
 mod error;
 mod locator;
 mod locator_package;
@@ -371,7 +372,14 @@ impl std::fmt::Display for Revision {
 
 impl std::fmt::Debug for Revision {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{self}")
+        if f.alternate() {
+            match self {
+                Revision::Semver(version) => write!(f, "Revision::Semver({version:?})"),
+                Revision::Opaque(version) => write!(f, "Revision::Opaque({version:?})"),
+            }
+        } else {
+            write!(f, "{self}")
+        }
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@
 
 use std::{borrow::Cow, num::ParseIntError, str::FromStr};
 
+use derive_new::new;
 use documented::Documented;
 use duplicate::duplicate;
 use serde::{Deserialize, Serialize};
@@ -23,6 +24,9 @@ pub use constraint::*;
 pub use locator::*;
 pub use locator_package::*;
 pub use locator_strict::*;
+
+#[doc(hidden)]
+pub use semver;
 
 /// `Fetcher` identifies a supported code host protocol.
 #[derive(
@@ -320,14 +324,16 @@ impl std::cmp::PartialOrd for Package {
 /// A "revision" is the version of the project in the code host.
 /// Some fetcher protocols (such as `apk`, `rpm-generic`, and `deb`)
 /// encode additional standardized information in the `Revision` of the locator.
-#[derive(Clone, Eq, PartialEq, Hash, Documented, ToSchema)]
+#[derive(Clone, Eq, PartialEq, Hash, Documented, ToSchema, new)]
 #[schema(example = json!("v1.0.0"))]
 pub enum Revision {
     /// The revision is valid semver.
     #[schema(value_type = String)]
+    #[new(into)]
     Semver(semver::Version),
 
     /// The revision is an opaque string.
+    #[new(into)]
     Opaque(String),
 }
 
@@ -353,6 +359,14 @@ impl From<String> for Revision {
 impl From<&str> for Revision {
     fn from(value: &str) -> Self {
         Self::from(value.to_string())
+    }
+}
+
+impl FromStr for Revision {
+    type Err = RevisionParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(Self::from(s.to_string()))
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,7 @@ mod locator_strict;
 
 pub use error::*;
 
+pub use constraint::*;
 pub use locator::*;
 pub use locator_package::*;
 pub use locator_strict::*;

--- a/src/locator.rs
+++ b/src/locator.rs
@@ -6,13 +6,13 @@ use getset::{CopyGetters, Getters};
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use utoipa::{
-    openapi::{ObjectBuilder, SchemaType},
     ToSchema,
+    openapi::{ObjectBuilder, SchemaType},
 };
 
 use crate::{
-    parse_org_package, Error, Fetcher, OrgId, Package, PackageLocator, ParseError, Revision,
-    StrictLocator,
+    Error, Fetcher, OrgId, Package, PackageLocator, ParseError, Revision, StrictLocator,
+    parse_org_package,
 };
 
 /// Convenience macro for creating a [`Locator`].
@@ -417,7 +417,7 @@ mod tests {
 
     use assert_matches::assert_matches;
     use impls::impls;
-    use itertools::{izip, Itertools};
+    use itertools::{Itertools, izip};
     use pretty_assertions::assert_eq;
     use proptest::prelude::*;
     use serde::Deserialize;

--- a/src/locator_package.rs
+++ b/src/locator_package.rs
@@ -6,8 +6,8 @@ use getset::{CopyGetters, Getters};
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use utoipa::{
-    openapi::{ObjectBuilder, SchemaType},
     ToSchema,
+    openapi::{ObjectBuilder, SchemaType},
 };
 
 use crate::{Error, Fetcher, Locator, OrgId, Package, StrictLocator};
@@ -273,7 +273,7 @@ impl<'a> ToSchema<'a> for StrictLocator {
 mod tests {
     use assert_matches::assert_matches;
     use impls::impls;
-    use itertools::{izip, Itertools};
+    use itertools::{Itertools, izip};
     use pretty_assertions::assert_eq;
     use serde::Deserialize;
     use static_assertions::const_assert;

--- a/src/locator_strict.rs
+++ b/src/locator_strict.rs
@@ -6,8 +6,8 @@ use getset::{CopyGetters, Getters};
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use utoipa::{
-    openapi::{ObjectBuilder, SchemaType},
     ToSchema,
+    openapi::{ObjectBuilder, SchemaType},
 };
 
 use crate::{Error, Fetcher, Locator, OrgId, Package, PackageLocator, ParseError, Revision};
@@ -253,7 +253,7 @@ impl<'a> ToSchema<'a> for PackageLocator {
 mod tests {
     use assert_matches::assert_matches;
     use impls::impls;
-    use itertools::{izip, Itertools};
+    use itertools::{Itertools, izip};
     use pretty_assertions::assert_eq;
     use serde::Deserialize;
     use static_assertions::const_assert;


### PR DESCRIPTION
# Overview

Extends the library with the concept of "constraints" and puts in place helpers for comparing locators and revisions to constraints.

Implements basic fallback comparisons:
- If the revisions are semver, compares according to semver rules.
- Otherwise compares lexicographically, doing its best to consider unicode.

## Acceptance criteria

We have a place to put locator revision comparison functionality.

## Testing plan

Automated tests

## Metrics

None

## Risks

No real risk

## References

Implements https://fossa.atlassian.net/browse/ANE-2362

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
