### PR TITLE
[ANE-2371] Add Gem constraint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,9 @@ enum-assoc = "1.2.4"
 unicase = "2.8.1"
 lexical-sort = "0.3.1"
 derive-new = "0.7.0"
+nom = "8.0.0"
+derive_more = { version = "2.0.1", features = ["full"] }
+tracing = "0.1.41"
 
 [dev-dependencies]
 assert_matches = "1.5.0"

--- a/src/constraint.rs
+++ b/src/constraint.rs
@@ -3,11 +3,13 @@ use documented::Documented;
 use enum_assoc::Assoc;
 use serde::{Deserialize, Serialize};
 use strum::Display;
+use tracing::warn;
 use utoipa::ToSchema;
 
 use crate::{Fetcher, Revision};
 
 mod fallback;
+mod gem;
 
 /// Describes version constraints supported by this crate.
 ///
@@ -109,6 +111,10 @@ impl Constraint {
     ///   In this instance [`Constraint::Compatible`] is a case-insensitive equality comparison.
     pub fn compare(&self, fetcher: Fetcher, target: &Revision) -> bool {
         match fetcher {
+            Fetcher::Gem => gem::compare(self, Fetcher::Gem, target).unwrap_or_else(|err| {
+                warn!("could not parse rubygems version '{err:?}'");
+                fallback::compare(self, Fetcher::Gem, target)
+            }),
             // If no specific comparitor is configured for this fetcher,
             // compare using the generic fallback.
             other => fallback::compare(self, other, target),

--- a/src/constraint.rs
+++ b/src/constraint.rs
@@ -112,7 +112,7 @@ impl Constraint {
     pub fn compare(&self, fetcher: Fetcher, target: &Revision) -> bool {
         match fetcher {
             Fetcher::Gem => gem::compare(self, Fetcher::Gem, target).unwrap_or_else(|err| {
-                warn!("could not parse rubygems version '{err:?}'");
+                warn!(?err, "could not compare version");
                 fallback::compare(self, Fetcher::Gem, target)
             }),
             // If no specific comparitor is configured for this fetcher,

--- a/src/constraint/gem.rs
+++ b/src/constraint/gem.rs
@@ -1,0 +1,345 @@
+use std::cmp::Ordering;
+
+use derive_more::Display;
+use nom::{
+    IResult, Parser,
+    branch::alt,
+    bytes::complete::{tag, take_while1},
+    character::complete::digit1,
+    combinator::map_res,
+    multi::{many1, separated_list0},
+};
+
+use thiserror::Error;
+
+use super::{Constraint, fallback};
+use crate::{Fetcher, Revision};
+
+/// Gem Versions and their Comparisons:
+///
+/// Per https://guides.rubygems.org/patterns/#semantic-versioning, rubygems urges semantic versioning,
+/// But does not dictate semantic versioning.
+///
+/// https://github.com/rubygems/rubygems/blob/master/lib/rubygems/version.rb gives us:
+///
+/// > If any part contains letters (currently only a-z are supported) then
+/// > that version is considered prerelease. Versions with a prerelease
+/// > part in the Nth part sort less than versions with N-1
+/// > parts. Prerelease parts are sorted alphabetically using the normal
+/// > Ruby string sorting rules. If a prerelease part contains both
+/// > letters and numbers, it will be broken into multiple parts to
+/// > provide expected sort behavior (1.0.a10 becomes 1.0.a.10, and is
+/// > greater than 1.0.a9).
+/// >
+/// > Prereleases sort between real releases (newest to oldest):
+/// >
+/// > 1. 1.0
+/// > 2. 1.0.b1
+/// > 3. 1.0.a.2
+/// > 4. 0.9
+/// >
+/// > If you want to specify a version restriction that includes both prereleases
+/// > and regular releases of the 1.x series this is the best way:
+/// >
+/// >   s.add_dependency 'example', '>= 1.0.0.a', '< 2.0.0'
+///
+/// An Advisory Example: ruby-advisory-db/gems/activesupport/CVE-2009-3009.yml
+///
+/// ```yaml
+/// unaffected_versions:
+///   - "< 2.0.0"
+/// patched_versions:
+///   - "~> 2.2.3"
+///   - ">= 2.3.4"
+/// ```
+///
+/// Note the "twiddle-wakka" syntax for pessimistic version matching.
+/// See here: https://guides.rubygems.org/patterns/#pessimistic-version-constraint
+/// So `~> 2.2.3` is equivalent to `>= 2.2.3,< 2.3.0`.
+/// Leaving out the patch, `~> 2.2` is equivalent to `>= 2.2.0,<3.0.0`.
+/// Finally, `~> 2` is the closest to ~=/Compatible, and is equivalent to `>= 2.0.0,<3.0.0`.
+pub fn compare(
+    constraint: &Constraint,
+    fetcher: Fetcher,
+    target: &Revision,
+) -> Result<bool, GemConstraintError> {
+    if let (Revision::Semver(_), Revision::Semver(_)) = (constraint.revision(), target) {
+        Ok(fallback::compare(constraint, fetcher, target))
+    } else {
+        let threshold = GemVersion::try_from(constraint.revision())?;
+        let target = GemVersion::try_from(target)?;
+        Ok(match constraint {
+            Constraint::Equal(_) => target == threshold,
+            Constraint::NotEqual(_) => target != threshold,
+            Constraint::Less(_) => target < threshold,
+            Constraint::LessOrEqual(_) => target <= threshold,
+            Constraint::Greater(_) => target > threshold,
+            Constraint::GreaterOrEqual(_) => target >= threshold,
+            Constraint::Compatible(_) => {
+                let mut stop_segments = threshold
+                    .segments
+                    .iter()
+                    .take_while(|s| !matches!(s, Segment::Prerelease(_)))
+                    .take(threshold.segments.len() - 1)
+                    .cloned()
+                    .collect::<Vec<_>>()
+                    .clone();
+                if let Some(Segment::Release(n)) = stop_segments.last_mut() {
+                    *n += 1;
+                }
+                let stop = GemVersion {
+                    segments: stop_segments,
+                };
+                target >= threshold && target < stop
+            }
+        })
+    }
+}
+
+/// Errors from running the gem constraint.
+#[derive(Error, Clone, PartialEq, Eq, Debug, Display)]
+pub enum GemConstraintError {
+    /// Errors from parsing Gem versions.
+    #[display("VersionParseError({version}, {message})")]
+    VersionParseError {
+        /// The failed-to-parse version
+        version: String,
+
+        /// The underlying parse error's message
+        message: String,
+    },
+}
+
+impl From<semver::Version> for GemVersion {
+    fn from(version: semver::Version) -> Self {
+        GemVersion {
+            segments: vec![
+                Segment::Release(version.major as usize),
+                Segment::Release(version.minor as usize),
+                Segment::Release(version.patch as usize),
+            ],
+        }
+    }
+}
+
+impl TryFrom<&Revision> for GemVersion {
+    type Error = GemConstraintError;
+
+    fn try_from(rev: &Revision) -> Result<Self, Self::Error> {
+        match rev {
+            Revision::Semver(semver) => Ok(GemVersion::from(semver.to_owned())),
+            Revision::Opaque(opaque) => {
+                GemVersion::parse(opaque.as_str())
+                    .map(|(_, v)| v)
+                    .map_err(|e| GemConstraintError::VersionParseError {
+                        version: opaque.to_string(),
+                        message: e.to_string(),
+                    })
+            }
+        }
+    }
+}
+
+impl TryFrom<Revision> for GemVersion {
+    type Error = GemConstraintError;
+
+    fn try_from(value: Revision) -> Result<Self, Self::Error> {
+        match value {
+            Revision::Semver(version) => Ok(version.into()),
+            Revision::Opaque(opaque) => match GemVersion::parse(opaque.as_str()) {
+                Ok((_, gem_version)) => Ok(gem_version),
+                Err(err) => Err(GemConstraintError::VersionParseError {
+                    version: opaque.to_string(),
+                    message: err.to_string(),
+                }),
+            },
+        }
+    }
+}
+
+/// A gem/bundler version.
+/// Usually but not always a sem-ver version.
+/// Can also include forms like `1.2.prerelease1`, which expand to `1.2.prerelease.1` and indicate prerelease versions.
+#[derive(Debug, PartialEq, Eq, Clone)]
+struct GemVersion {
+    /// The parts of the version. Prereleases with numbers end up in multiple parts (e.g. 1.0.a2 has segments 1, 0, a, and 2).
+    segments: Vec<Segment>,
+}
+
+impl GemVersion {
+    /// Parse a rubygems version, as described by https://ruby-doc.org/stdlib-3.0.0/libdoc/rubygems/rdoc/Gem/Version.html.
+    pub fn parse(input: &str) -> IResult<&str, Self> {
+        // Usually a gem version is of the familiar form `major.minor.patch`.
+        // Sometimes it includes further nesting or prerelease strings a la the examples `1.0.a2` or `0.9.b.0`.
+
+        /// Parses a numeric release segment.
+        fn release(input: &str) -> IResult<&str, Segment> {
+            map_res(digit1, |s: &str| s.parse::<usize>().map(Segment::Release)).parse(input)
+        }
+
+        /// Parses an alphabetic pre-release segment.
+        fn prerelease(input: &str) -> IResult<&str, Segment> {
+            map_res(
+                take_while1(|c: char| c.is_alphabetic()),
+                |s: &str| -> std::result::Result<Segment, std::convert::Infallible> {
+                    Ok(Segment::Prerelease(s.to_string()))
+                },
+            )
+            .parse(input)
+        }
+
+        /// Parses either kind of segment.
+        fn segment(input: &str) -> IResult<&str, Segment> {
+            alt((release, prerelease)).parse(input)
+        }
+
+        /// Since segments are not reliably "."-delimted, this parses the inner segments of a verison (`a2` becomes 'a, then 2', for example.)
+        fn inner_segments(input: &str) -> IResult<&str, Vec<Segment>> {
+            many1(segment).parse(input)
+        }
+
+        /// Parses the segments of a gem version and flattens the result.
+        fn version(input: &str) -> IResult<&str, GemVersion> {
+            let (input, nested) = separated_list0(tag("."), inner_segments).parse(input)?;
+            let segments = nested.into_iter().flatten().collect();
+            Ok((input, GemVersion { segments }))
+        }
+
+        let input = input.trim();
+        version(input)
+    }
+}
+
+/// Either a number or a prerelease-string
+#[derive(Clone, Debug, PartialEq, Eq)]
+enum Segment {
+    /// A normal release. The '1' or '0' in '1.0.a2'.
+    Release(usize),
+
+    /// A pre-release. The 'a' in '1.0.a2'.
+    Prerelease(String),
+}
+
+impl PartialOrd for Segment {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for Segment {
+    fn cmp(&self, other: &Self) -> Ordering {
+        match (self, other) {
+            (Segment::Release(l), Segment::Release(r)) => l.cmp(r),
+            (Segment::Prerelease(l), Segment::Prerelease(r)) => lexical_sort::lexical_cmp(l, r),
+            (Segment::Prerelease(_), Segment::Release(_)) => Ordering::Less,
+            (Segment::Release(_), Segment::Prerelease(_)) => Ordering::Greater,
+        }
+    }
+}
+
+impl PartialOrd for GemVersion {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for GemVersion {
+    fn cmp(&self, other: &Self) -> Ordering {
+        let max_len = self.segments.len().max(other.segments.len());
+        for i in 0..max_len {
+            let l = self.segments.get(i);
+            let r = other.segments.get(i);
+            match (l, r) {
+                (Some(l), Some(r)) => {
+                    let cmp = l.cmp(r);
+                    if cmp != Ordering::Equal {
+                        return cmp;
+                    }
+                }
+                (Some(_), None) => return Ordering::Greater,
+                (None, Some(_)) => return Ordering::Less,
+                (None, None) => return Ordering::Equal,
+            }
+        }
+        Ordering::Equal
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use simple_test_case::test_case;
+
+    use super::*;
+    use crate::{Revision, constraint};
+
+    const FETCHER: Fetcher = Fetcher::Gem;
+
+    #[test_case(constraint!(Compatible => 1, 2, 3), Revision::from("1.2.3"); "1.2.3_compatible_1.2.3")]
+    #[test_case(constraint!(Compatible => 1, 2, 3), Revision::from("1.2.4"); "1.2.4_compatible_1.2.3")]
+    #[test_case(constraint!(Compatible => 1, 2, 3), Revision::from("2.0.0"); "2.0.0_not_compatible_1.2.3")]
+    #[test_case(constraint!(Equal => 1, 2, 3), Revision::from("1.2.3"); "1.2.3_equal_1.2.3")]
+    #[test_case(constraint!(Equal => 1, 2, 3), Revision::from("1.2.4"); "1.2.4_not_equal_1.2.3")]
+    #[test_case(constraint!(NotEqual => 1, 2, 3), Revision::from("1.2.3"); "1.2.3_not_notequal_1.2.3")]
+    #[test_case(constraint!(NotEqual => 1, 2, 3), Revision::from("1.2.4"); "1.2.4_notequal_1.2.3")]
+    #[test_case(constraint!(Less => 1, 2, 3), Revision::from("1.2.2"); "1.2.2_less_1.2.3")]
+    #[test_case(constraint!(Less => 1, 2, 3), Revision::from("1.2.3"); "1.2.3_not_less_1.2.3")]
+    #[test_case(constraint!(LessOrEqual => 1, 2, 3), Revision::from("1.2.2"); "1.2.2_less_or_equal_1.2.3")]
+    #[test_case(constraint!(LessOrEqual => 1, 2, 3), Revision::from("1.2.3"); "1.2.3_less_or_equal_1.2.3")]
+    #[test_case(constraint!(LessOrEqual => 1, 2, 3), Revision::from("1.2.4"); "1.2.4_not_less_or_equal_1.2.3")]
+    #[test_case(constraint!(Greater => 1, 2, 3), Revision::from("1.2.4"); "1.2.4_greater_1.2.3")]
+    #[test_case(constraint!(Greater => 1, 2, 3), Revision::from("1.2.3"); "1.2.3_not_greater_1.2.3")]
+    #[test_case(constraint!(GreaterOrEqual => 1, 2, 3), Revision::from("1.2.4"); "1.2.4_greater_or_equal_1.2.3")]
+    #[test_case(constraint!(GreaterOrEqual => 1, 2, 3), Revision::from("1.2.3"); "1.2.3_greater_or_equal_1.2.3")]
+    #[test_case(constraint!(GreaterOrEqual => 1, 2, 3), Revision::from("1.2.2"); "1.2.2_not_greater_or_equal_1.2.3")]
+    #[test]
+    fn compare_semver_acts_like_fallback(constraint: Constraint, target: Revision) {
+        let expected = fallback::compare(&constraint, FETCHER, &target);
+        assert_eq!(
+            compare(&constraint, FETCHER, &target).expect("should not have a parse error"),
+            expected,
+            "compare '{target}' to '{constraint}', expected: {expected}",
+        );
+    }
+
+    #[test_case(constraint!(GreaterOrEqual => "1.2.3.4"), Revision::from("1.2.3.5"), true; "1.2.3.4_greater_than_1.2.3.5")]
+    #[test_case(constraint!(Compatible => "1.2.3.4.5"), Revision::from("1.2.3.4.5.6"), true; "1.2.3.4.5_compat_1.2.3.4.5.6")]
+    #[test_case(constraint!(Compatible => "1.2.3.4.5"), Revision::from("1.2.3.5"), false; "1.2.3.5_not_compat_1.2.3.4.5")]
+    #[test_case(constraint!(Compatible => 1, 2, 0), Revision::from("1.2.3"), true; "1.2_compat_1.2.3")]
+    #[test_case(constraint!(Compatible => 1, 2, 0), Revision::from("1.3.4"), false; "1.2_compat_1.3.4")]
+    #[test_case(constraint!(Compatible => "1.2.a.0"), Revision::from("1.2.a0"), true; "1.2.a.0_compat_1.2.a0")]
+    #[test_case(constraint!(GreaterOrEqual => "1.2.prerelease0"), Revision::from("1.2.prerelease1"), true; "1.2.prerelease1_greater_or_equal_1.2prerelease0")]
+    #[test_case(constraint!(GreaterOrEqual => "1.2.3.4"), Revision::from("1.2.3.5"), true; "1.2.3.5_greater_or_equal_1.2.3.4")]
+    #[test_case(constraint!(GreaterOrEqual => "1.2.a.0"), Revision::from("1.2.a0"), true; "1.2.a.0_greater_or_equal_1.2a0")]
+    #[test_case(constraint!(Equal => "1.2.a.0"), Revision::from("1.2.a0"), true; "1.2.a.0_equal_1.2a0")]
+    #[test]
+    fn compare_ruby_specific_oddities(constraint: Constraint, target: Revision, expected: bool) {
+        assert_eq!(
+            compare(&constraint, FETCHER, &target).expect("should not have a parse error"),
+            expected,
+            "compare '{target}' to '{constraint}', expected: {expected}"
+        );
+    }
+
+    #[test_case(constraint!(Compatible => "abcd"), Revision::from("AbCd"); "abcd_compatible_AbCd")]
+    #[test_case(constraint!(Compatible => "abcd"), Revision::from("AbCdE"); "abcd_not_compatible_AbCdE")]
+    #[test_case(constraint!(Equal => "abcd"), Revision::from("abcd"); "abcd_equal_abcd")]
+    #[test_case(constraint!(Equal => "abcd"), Revision::from("aBcD"); "abcd_not_equal_aBcD")]
+    #[test_case(constraint!(NotEqual => "abcd"), Revision::from("abcde"); "abcd_notequal_abcde")]
+    #[test_case(constraint!(NotEqual => "abcd"), Revision::from("abcd"); "abcd_not_notequal_abcd")]
+    #[test_case(constraint!(Less => "a"), Revision::from("b"); "a_less_b")]
+    #[test_case(constraint!(Less => "a"), Revision::from("a"); "a_not_less_a")]
+    #[test_case(constraint!(Greater => "b"), Revision::from("a"); "b_greater_a")]
+    #[test_case(constraint!(Greater => "b"), Revision::from("c"); "b_not_greater_c")]
+    #[test_case(constraint!(Less => "あ"), Revision::from("え"); "jp_a_less_e")]
+    #[test_case(constraint!(Greater => "え"), Revision::from("あ"); "jp_e_greater_a")]
+    #[test_case(constraint!(Equal => "あ"), Revision::from("あ"); "jp_a_equal_a")]
+    #[test_case(constraint!(Compatible => "Maße"), Revision::from("MASSE"); "gr_masse_compatible_MASSE")]
+    fn compare_opaque(constraint: Constraint, target: Revision) {
+        let expected = fallback::compare(&constraint, FETCHER, &target);
+        assert_eq!(
+            compare(&constraint, FETCHER, &target).expect("should not have a parse error"),
+            expected,
+            "compare '{target}' to '{constraint}', expected: {expected}"
+        );
+    }
+}

--- a/src/constraint/gem.rs
+++ b/src/constraint/gem.rs
@@ -6,7 +6,10 @@ use nom::{
     branch::alt,
     bytes::complete::{tag, take_while1},
     character::complete::digit1,
+    character::complete::{char, multispace0},
     combinator::map_res,
+    combinator::{opt, recognize},
+    multi::separated_list1,
     multi::{many1, separated_list0},
     sequence::{delimited, pair},
 };
@@ -101,12 +104,6 @@ pub fn compare(
 /// Parses a string into a vector of constraints.
 /// See [Gem::Requirement](https://github.com/rubygems/rubygems/blob/master/lib/rubygems/requirement.rb) for more.
 pub fn parse_constraints(input: &str) -> Result<Vec<Constraint>, GemConstraintError> {
-    use nom::{
-        character::complete::{char, multispace0},
-        combinator::{map, opt, recognize},
-        multi::separated_list1,
-    };
-
     // Parse operators
     fn operator(input: &str) -> IResult<&str, &str> {
         alt((

--- a/src/constraint/gem.rs
+++ b/src/constraint/gem.rs
@@ -385,18 +385,18 @@ mod tests {
     const FETCHER: Fetcher = Fetcher::Gem;
 
     #[test_case(">= 1.0.0", vec![constraint!(GreaterOrEqual => "1.0.0")]; "1.0.0_>=_1.0.0")]
-    #[test_case("~> 2.5", vec![constraint!(Compatible => "2.5")]; "2.5.0_~>_2.5")]
+    #[test_case("~> 2.5", vec![constraint!(Compatible => "2.5")]; "2.5_~>_2.5")]
     #[test_case("< 3.0.0", vec![constraint!(Less => "3.0.0")]; "3.0.0_<_3.0.0")]
-    #[test_case(">= 1.0, < 2.0", vec![constraint!(GreaterOrEqual => "1.0"), constraint!(Less => "2.0")]; "1.0.0_>=_1.0_AND_<_2.0")]
+    #[test_case(">= 1.0, < 2.0", vec![constraint!(GreaterOrEqual => "1.0"), constraint!(Less => "2.0")]; "1.0_>=_1.0_AND_<_2.0")]
     #[test_case("= 1.2.3", vec![constraint!(Equal => "1.2.3")]; "1.2.3_=_1.2.3")]
     #[test_case("!= 1.9.3", vec![constraint!(NotEqual => "1.9.3")]; "1.9.3_!=_1.9.3")]
-    #[test_case("~> 2.2, >= 2.2.1", vec![constraint!(Compatible => "2.2"), constraint!(GreaterOrEqual => "2.2.1")]; "2.2.0_~>_2.2_AND_>=_2.2.1")]
+    #[test_case("~> 2.2, >= 2.2.1", vec![constraint!(Compatible => "2.2"), constraint!(GreaterOrEqual => "2.2.1")]; "2.2_~>_2.2_AND_>=_2.2.1")]
     #[test_case("> 1.0.0.pre.alpha", vec![constraint!(Greater => "1.0.0.pre.alpha")]; "1.0.0.pre.alpha_>_1.0.0.pre.alpha")]
     #[test_case("~> 1.0.0.beta2", vec![constraint!(Compatible => "1.0.0.beta2")]; "1.0.0.beta2_~>_1.0.0.beta2")]
     #[test_case("= 1.0.0.rc1", vec![constraint!(Equal => "1.0.0.rc1")]; "1.0.0.rc1_=_1.0.0.rc1")]
     #[test_case(">= 0.8.0, < 1.0.0.beta", vec![constraint!(GreaterOrEqual => "0.8.0"), constraint!(Less => "1.0.0.beta")]; "0.8.0_>=_0.8.0_AND_<_1.0.0.beta")]
     #[test_case("~> 3.2.0.rc3", vec![constraint!(Compatible => "3.2.0.rc3")]; "3.2.0.rc3_~>_3.2.0.rc3")]
-    #[test_case(">= 4.0.0.alpha, < 5", vec![constraint!(GreaterOrEqual => "4.0.0.alpha"), constraint!(Less => "5")]; "4.0.0.alpha_>=_4.0.0.alpha_AND_<_5.0.0")]
+    #[test_case(">= 4.0.0.alpha, < 5", vec![constraint!(GreaterOrEqual => "4.0.0.alpha"), constraint!(Less => "5")]; "4.0.0.alpha_>=_4.0.0.alpha_AND_<_5")]
     #[test]
     fn test_ruby_constraints_parsing(input: &str, expected: Vec<Constraint>) {
         let actual = parse_constraints(input).expect("should parse constraint");


### PR DESCRIPTION
# Overview

Implement the Gem [Constraint](https://github.com/fossas/locator-rs/pull/14).

## Acceptance criteria

- For gems obeying Semver, this constraint should work just like the fallback does already
- For gems with totally inscrutable versions, this constraint should work just like the fallback does already
- For sequences of arbitrarily long numerics e.g. `1.2.3.4`, this should treat `~>` constraints as binding to the N-1th position. So `1.2.3.4.5 ~> 1.2.3.4`, but `1.2.3.5` does not, for example.
- For prereleases, like `1.2.3prerelease0`, ('prerelease' is not a magic string, any alphabetic string is valid there), this should treat them identically to `1.2.3.prerelease.0`. `1.2.3.prerelease.0` should be less than `1.2.3.prerelease.1` and the numeric portion after the prerelease tag matters.

## Testing plan

I have validated this with unit tests, but have some follow-up questions around some of the cases which I believe to be correct but do not 100% line up with the fallback.

## Metrics

N/A

## Risks

Some of the ruby docs and comments indicate that only "a-z" are supported as valid prerelease tag characters, and I don't know if this is strict enough in that regard to be entirely correct. Namely, I don't know if ruby believe that "a-z" contains, A-Z (I'd think not but it's a comment in a sourcefile in rubygems and the regexes indicate otherwise as I read them.)

Point being, I'm not 100% sure how sure Bundler is of its semantics, so if any edge-cases occur to the reader, please bring them up and I'll add a test.


## References

- [rubygems version class](https://github.com/rubygems/rubygems/blob/master/lib/rubygems/version.rb)
- [rubygems pattern documentation](https://guides.rubygems.org/patterns/)
- [existing scraper code](https://github.com/fossas/sparkle/blob/main/worker/src/scrape/ruby.rs)


## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
