### PR TITLE
Update deps, swap to utoipa v5

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,22 +1,22 @@
 [package]
 name = "locator"
-version = "3.0.0"
+version = "4.0.0"
 edition = "2024"
 
 [dependencies]
 alphanumeric-sort = "1.5.3"
-getset = "0.1.2"
-pretty_assertions = "1.4.0"
-serde = { version = "1.0.140", features = ["derive"] }
+getset = "0.1.5"
+pretty_assertions = "1.4.1"
+serde = { version = "1.0.219", features = ["derive"] }
 strum = { version = "0.27.1", features = ["derive"] }
-thiserror = "1.0.31"
-utoipa = "4.2.3"
-serde_json = "1.0.95"
-documented = "0.7.1"
-semver = "1.0.23"
+thiserror = "2"
+utoipa = "5"
+serde_json = "1.0.140"
+documented = "0.9"
+semver = "1.0.26"
 bon = "3.6.3"
 duplicate = "2.0.0"
-lazy-regex = { version = "3.3.0", features = ["regex"] }
+lazy-regex = { version = "3.4.1", features = ["regex"] }
 enum-assoc = "1.2.4"
 unicase = "2.8.1"
 lexical-sort = "0.3.1"
@@ -30,7 +30,7 @@ derivative = "2.2.0"
 assert_matches = "1.5.0"
 impls = "1.0.3"
 itertools = "0.14.0"
-pretty_assertions = "1.4.0"
-proptest = "1.0.0"
-simple_test_case = "1.2.0"
+pretty_assertions = "1.4.1"
+proptest = "1.6.0"
+simple_test_case = "1.3.0"
 static_assertions = "1.1.0"

--- a/src/locator.rs
+++ b/src/locator.rs
@@ -5,9 +5,10 @@ use documented::Documented;
 use getset::{CopyGetters, Getters};
 use serde::{Deserialize, Serialize};
 use serde_json::json;
+use std::borrow::Cow;
 use utoipa::{
-    ToSchema,
-    openapi::{ObjectBuilder, SchemaType},
+    PartialSchema, ToSchema,
+    openapi::{ObjectBuilder, Type},
 };
 
 use crate::{
@@ -410,21 +411,21 @@ impl FromStr for Locator {
     }
 }
 
-impl<'a> ToSchema<'a> for Locator {
-    fn schema() -> (
-        &'a str,
-        utoipa::openapi::RefOr<utoipa::openapi::schema::Schema>,
-    ) {
-        (
-            "Locator",
-            ObjectBuilder::new()
-                .description(Some(Self::DOCS))
-                .example(Some(json!("git+github.com/fossas/locator-rs$v1.0.0")))
-                .min_length(Some(3))
-                .schema_type(SchemaType::String)
-                .build()
-                .into(),
-        )
+impl PartialSchema for Locator {
+    fn schema() -> utoipa::openapi::RefOr<utoipa::openapi::schema::Schema> {
+        ObjectBuilder::new()
+            .description(Some(Self::DOCS))
+            .examples([json!("git+github.com/fossas/locator-rs$v1.0.0")])
+            .min_length(Some(3))
+            .schema_type(Type::String)
+            .build()
+            .into()
+    }
+}
+
+impl ToSchema for Locator {
+    fn name() -> Cow<'static, str> {
+        Cow::Borrowed("Locator")
     }
 }
 

--- a/src/locator_package.rs
+++ b/src/locator_package.rs
@@ -5,9 +5,10 @@ use documented::Documented;
 use getset::{CopyGetters, Getters};
 use serde::{Deserialize, Serialize};
 use serde_json::json;
+use std::borrow::Cow;
 use utoipa::{
-    ToSchema,
-    openapi::{ObjectBuilder, SchemaType},
+    PartialSchema, ToSchema,
+    openapi::{ObjectBuilder, Type},
 };
 
 use crate::{Error, Fetcher, Locator, OrgId, Package, StrictLocator};
@@ -251,21 +252,21 @@ impl FromStr for PackageLocator {
     }
 }
 
-impl<'a> ToSchema<'a> for StrictLocator {
-    fn schema() -> (
-        &'a str,
-        utoipa::openapi::RefOr<utoipa::openapi::schema::Schema>,
-    ) {
-        (
-            "StrictLocator",
-            ObjectBuilder::new()
-                .description(Some(Self::DOCS))
-                .example(Some(json!("git+github.com/fossas/locator-rs$v1.0.0")))
-                .min_length(Some(3))
-                .schema_type(SchemaType::String)
-                .build()
-                .into(),
-        )
+impl PartialSchema for PackageLocator {
+    fn schema() -> utoipa::openapi::RefOr<utoipa::openapi::schema::Schema> {
+        ObjectBuilder::new()
+            .description(Some(Self::DOCS))
+            .examples([json!("git+github.com/fossas/locator-rs")])
+            .min_length(Some(3))
+            .schema_type(Type::String)
+            .build()
+            .into()
+    }
+}
+
+impl ToSchema for PackageLocator {
+    fn name() -> Cow<'static, str> {
+        Cow::Borrowed("PackageLocator")
     }
 }
 

--- a/src/locator_strict.rs
+++ b/src/locator_strict.rs
@@ -5,9 +5,10 @@ use documented::Documented;
 use getset::{CopyGetters, Getters};
 use serde::{Deserialize, Serialize};
 use serde_json::json;
+use std::borrow::Cow;
 use utoipa::{
-    ToSchema,
-    openapi::{ObjectBuilder, SchemaType},
+    PartialSchema, ToSchema,
+    openapi::{ObjectBuilder, Type},
 };
 
 use crate::{Error, Fetcher, Locator, OrgId, Package, PackageLocator, ParseError, Revision};
@@ -231,21 +232,21 @@ impl FromStr for StrictLocator {
     }
 }
 
-impl<'a> ToSchema<'a> for PackageLocator {
-    fn schema() -> (
-        &'a str,
-        utoipa::openapi::RefOr<utoipa::openapi::schema::Schema>,
-    ) {
-        (
-            "PackageLocator",
-            ObjectBuilder::new()
-                .description(Some(Self::DOCS))
-                .example(Some(json!("git+github.com/fossas/locator-rs")))
-                .min_length(Some(3))
-                .schema_type(SchemaType::String)
-                .build()
-                .into(),
-        )
+impl PartialSchema for StrictLocator {
+    fn schema() -> utoipa::openapi::RefOr<utoipa::openapi::schema::Schema> {
+        ObjectBuilder::new()
+            .description(Some(Self::DOCS))
+            .examples([json!("git+github.com/fossas/locator-rs$v1.0.0")])
+            .min_length(Some(3))
+            .schema_type(Type::String)
+            .build()
+            .into()
+    }
+}
+
+impl ToSchema for StrictLocator {
+    fn name() -> Cow<'static, str> {
+        Cow::Borrowed("StrictLocator")
     }
 }
 


### PR DESCRIPTION
# Overview

Updates all deps and swaps to `utoipa` v5.

## Acceptance criteria

Compatible with `utoipa` v5 which we're moving to in other services.

## Testing plan

Automated tests

## Metrics

None

## Risks

Services that don't update to utoipa v5 won't be able to use this version or later of the library.

## References

None

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
