### PR TITLE
Refactor: generalized constraints

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,10 @@ nom = "8.0.0"
 derive_more = { version = "2.0.1", features = ["full"] }
 tracing = "0.1.41"
 derivative = "2.2.0"
+subenum = "1.1.2"
+versions = { version = "7.0.0", features = ["serde"] }
+compact_str = { version = "0.9.0", features = ["serde"] }
+either = { version = "1.15.0", features = ["serde"] }
 
 [dev-dependencies]
 assert_matches = "1.5.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "locator"
-version = "4.0.0"
+version = "5.0.0"
 edition = "2024"
 
 [dependencies]

--- a/src/constraint/nuget.rs
+++ b/src/constraint/nuget.rs
@@ -47,6 +47,7 @@
 use std::{cmp::Ordering, fmt::Write, str::FromStr};
 
 use bon::Builder;
+use compact_str::ToCompactString;
 use derivative::Derivative;
 use nom::{
     IResult, Parser,
@@ -790,7 +791,7 @@ pub fn parse_constraints(input: &str) -> Result<Vec<Constraint<Revision>>, Nuget
         )
         .parse(input)?;
 
-        let rev = Revision::Opaque(ver.to_string());
+        let rev = Revision::Opaque(ver.to_compact_string());
 
         let constraint = match op {
             "=" => Constraint::Equal(rev),

--- a/tests/it/constraint.rs
+++ b/tests/it/constraint.rs
@@ -67,3 +67,36 @@ fn cargo_parse_and_compare(req: &str, ver: &str, expected: bool) {
         "Expected {req:?} to match {ver:?}"
     );
 }
+
+#[test_case("=1.2.3", "1.2.3", true; "eq1.2.3_includes_1.2.3")]
+#[test_case("=1.2.3", "1.2.4", false; "eq1.2.3_excludes_1.2.4")]
+#[test_case(">1.2.3", "1.2.4", true; "gt1.2.3_includes_1.2.4")]
+#[test_case(">1.2.3", "1.2.2", false; "gt1.2.3_excludes_1.2.2")]
+#[test_case("<1.2.3", "1.2.2", true; "lt1.2.3_includes_1.2.2")]
+#[test_case("<1.2.3", "1.2.4", false; "lt1.2.3_excludes_1.2.4")]
+#[test_case(">=1.2.3", "1.2.3", true; "gte1.2.3_includes_1.2.3")]
+#[test_case(">=1.2.3", "1.2.2", false; "gte1.2.3_excludes_1.2.2")]
+#[test_case("<=1.2.3", "1.2.3", true; "lte1.2.3_includes_1.2.3")]
+#[test_case("<=1.2.3", "1.2.4", false; "lte1.2.3_excludes_1.2.4")]
+#[test_case("~1.2.3", "1.2.4", true; "tilde1.2.3_includes_1.2.4")]
+#[test_case("~1.2.3", "1.3.0", true; "tilde1.2.3_includes_1.3.0")]
+#[test_case("^1.2.3", "1.9.9", true; "caret1.2.3_includes_1.9.9")]
+#[test_case("^1.2.3", "2.0.0", false; "caret1.2.3_excludes_2.0.0")]
+#[test_case("!=1.2.3", "1.2.4", true; "neq1.2.3_includes_1.2.4")]
+#[test_case("!=1.2.3", "1.2.3", false; "neq1.2.3_excludes_1.2.3")]
+#[test_case(">1.0.0,<2.0.0", "1.5.0", true; "range_includes_1.5.0")]
+#[test_case(">1.0.0,<2.0.0", "2.0.0", false; "range_excludes_2.0.0")]
+#[test_case(">=1.0.0,<=1.5.0", "1.5.0", true; "inclusive_range_includes_1.5.0")]
+#[test_case(">=1.0.0,<=1.5.0", "1.5.1", false; "inclusive_range_excludes_1.5.1")]
+#[test_case("^1.0.0,!=1.2.3", "1.2.3", false; "complex_condition_excludes_1.2.3")]
+#[test_case("^1.0.0,!=1.2.3", "1.3.0", true; "complex_condition_includes_1.3.0")]
+#[test]
+fn arbitrary_parse_and_compare(req: &str, ver: &str, expected: bool) {
+    let req = locator::constraint::parse(req).expect("parse constraint");
+    let ver = Revision::from(ver);
+    assert_eq!(
+        req.all_match(&ver),
+        expected,
+        "Expected {req:?} to match {ver:?}"
+    );
+}


### PR DESCRIPTION
# Overview

Refactors the library to provide _generalized constraints_ and _generalized version handling_ using the [`versions`](https://docs.rs/versions/latest/versions/index.html) crate.

Also does some minor cleanup:
- Reduces allocations of strings by keeping original inputs around
- Uses `compact_str` for most fields to reduce allocations further
  - The two strings that routinely get created in locators are `Package` and `Revision`
  - Both of these strings are usually quite short
  - `compact_str` can keep strings that are less than 24 bytes long on the stack
- Some general convenience cleanup like `impl From<&Locator> for Locator`

## Acceptance criteria

The locator library is able to handle the general purpose case of version comparison without special logic.

## Testing plan

- Added new automated tests to exercise the new logic.
- Validated old automated tests still function as expected.

## Metrics

No direct metrics

## Risks

No major risk- at worst we might parse constraints wrong when there's not special handling for it, but this is better than not parsing at all.

## References


## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
