### PR TITLE
Fix macro hygiene

### DIFF
--- a/locator-codegen/Cargo.toml
+++ b/locator-codegen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "locator-codegen"
-version = "0.1.0"
+version = "4.0.1"
 edition = "2024"
 
 [lints]

--- a/locator/Cargo.toml
+++ b/locator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "locator"
-version = "4.0.0"
+version = "4.0.1"
 edition = "2024"
 
 [lints]

--- a/locator/src/constraint.rs
+++ b/locator/src/constraint.rs
@@ -800,7 +800,7 @@ macro_rules! constraint {
 #[macro_export]
 macro_rules! constraints {
     ($({ $variant:ident => $($revision:tt)* }),* $(,)?) => {
-        Constraints::from(vec![
+        $crate::Constraints::from(vec![
             $(
                 $crate::Constraint::$variant($($revision)*)
             ),*

--- a/locator/src/lib.rs
+++ b/locator/src/lib.rs
@@ -47,6 +47,7 @@ use utoipa::ToSchema;
 #[doc(hidden)]
 pub mod macro_support {
     pub use bon;
+    pub use non_empty_string;
     pub use semver;
     pub use versions;
 }

--- a/locator/src/revision.rs
+++ b/locator/src/revision.rs
@@ -272,7 +272,9 @@ macro_rules! revision {
         $crate::Revision::Version($crate::Version::new_semver($major, $minor, $patch))
     };
     ($input:expr) => {
-        $crate::Revision::from(non_empty_string::non_empty_string!($input))
+        $crate::Revision::from($crate::macro_support::non_empty_string::non_empty_string!(
+            $input
+        ))
     };
 
     // This is only meant for use internally, so it's undocumented.


### PR DESCRIPTION
# Overview

When using a couple macros from a separate project, the macros incorrectly required importing dependencies.

## Acceptance criteria

All exported macros are hygienic: they don't require random other packages/types in scope or in the project.

## Testing plan

We don't really have a good way to test this since all automated tests in this project automatically have the same dependencies as the project itself.

## Metrics

None

## Risks

None

## References

None

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
