### PR TITLE
parser enhancements

### DIFF
--- a/locator-codegen/Cargo.toml
+++ b/locator-codegen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "locator-codegen"
-version = "4.0.2"
+version = "4.1.0"
 edition = "2024"
 
 [lints]

--- a/locator-codegen/src/lib.rs
+++ b/locator-codegen/src/lib.rs
@@ -254,6 +254,7 @@ pub fn ecosystems(attr: TokenStream, item: TokenStream) -> TokenStream {
     TokenStream::from(quote! {
         #(#docs)*
         #vis mod #name {
+            use crate as locator;
             #invalid_conversion_err;
             #ecosystems
             #subsets

--- a/locator-codegen/src/locator_parts.rs
+++ b/locator-codegen/src/locator_parts.rs
@@ -88,29 +88,16 @@ impl Invocation {
             package,
             revision,
         } = &self.types;
-        let ecosystem_doc = field_doc_ecosystem();
-        let organization_doc = field_doc_organization();
-        let package_doc = field_doc_package();
-        let revision_doc = field_doc_revision();
-
         quote! {
             #[locator::macro_support::bon::bon]
             impl #struct_name {
                 /// Construct a new instance with the provided values.
                 #[builder]
                 pub fn builder(
-                    #[doc = #ecosystem_doc]
-                    #[builder(into)]
-                    ecosystem: #ecosystem,
-                    #[doc = #organization_doc]
-                    #[builder(into)]
-                    organization: #organization,
-                    #[doc = #package_doc]
-                    #[builder(into)]
-                    package: #package,
-                    #[doc = #revision_doc]
-                    #[builder(into)]
-                    revision: #revision,
+                    #[builder(into)] ecosystem: #ecosystem,
+                    #[builder(into)] organization: #organization,
+                    #[builder(into)] package: #package,
+                    #[builder(into)] revision: #revision,
                 ) -> Self {
                     Self(locator::LocatorParts::new(
                         ecosystem,

--- a/locator-codegen/src/locator_parts.rs
+++ b/locator-codegen/src/locator_parts.rs
@@ -59,11 +59,11 @@ impl Invocation {
                     locator::LocatorParts::parse(input).map(Self)
                 }
                 /// Extract the instance to its parts.
-                pub(crate) fn into_parts(self) -> locator::LocatorParts<#ecosystem, #organization, #package, #revision> {
+                pub fn into_parts(self) -> locator::LocatorParts<#ecosystem, #organization, #package, #revision> {
                     self.0
                 }
                 /// Construct an instance from its parts.
-                pub(crate) fn from_parts(parts: locator::LocatorParts<#ecosystem, #organization, #package, #revision>) -> Self {
+                pub fn from_parts(parts: locator::LocatorParts<#ecosystem, #organization, #package, #revision>) -> Self {
                     Self(parts)
                 }
             }
@@ -88,6 +88,10 @@ impl Invocation {
             package,
             revision,
         } = &self.types;
+        let ecosystem_doc = field_doc_ecosystem();
+        let organization_doc = field_doc_organization();
+        let package_doc = field_doc_package();
+        let revision_doc = field_doc_revision();
 
         quote! {
             #[locator::macro_support::bon::bon]
@@ -95,10 +99,18 @@ impl Invocation {
                 /// Construct a new instance with the provided values.
                 #[builder]
                 pub fn builder(
-                    #[builder(into)] ecosystem: #ecosystem,
-                    #[builder(into)] organization: #organization,
-                    #[builder(into)] package: #package,
-                    #[builder(into)] revision: #revision,
+                    #[doc = #ecosystem_doc]
+                    #[builder(into)]
+                    ecosystem: #ecosystem,
+                    #[doc = #organization_doc]
+                    #[builder(into)]
+                    organization: #organization,
+                    #[doc = #package_doc]
+                    #[builder(into)]
+                    package: #package,
+                    #[doc = #revision_doc]
+                    #[builder(into)]
+                    revision: #revision,
                 ) -> Self {
                     Self(locator::LocatorParts::new(
                         ecosystem,

--- a/locator/Cargo.toml
+++ b/locator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "locator"
-version = "4.0.2"
+version = "4.1.0"
 edition = "2024"
 
 [lints]
@@ -39,8 +39,9 @@ assert_matches = "1.5.0"
 color-eyre = "0.6.5"
 impls = "1.0.3"
 itertools = "0.14.0"
+maplit = "1.0.2"
 monostate = "0.1.14"
-pretty_assertions = "1.4.1"
+pretty_assertions = { version = "1.4.1", features = ["unstable"] }
 proptest = "1.6.0"
 simple_test_case = "1.3.0"
 static_assertions = "1.1.0"

--- a/locator/src/lib.rs
+++ b/locator/src/lib.rs
@@ -49,6 +49,7 @@ pub mod macro_support {
     pub use bon;
     pub use non_empty_string;
     pub use semver;
+    pub use serde_plain;
     pub use versions;
 }
 
@@ -168,10 +169,6 @@ pub mod macro_support {
     Private => User, "user";
 )]
 pub struct ecosystems;
-
-serde_plain::derive_display_from_serialize!(ecosystems::Ecosystem);
-serde_plain::derive_display_from_serialize!(ecosystems::EcosystemPublic);
-serde_plain::derive_display_from_serialize!(ecosystems::EcosystemPrivate);
 
 /// This field indicates no value: it's the equivalent of an always-`None` `Option<()>`.
 ///

--- a/locator/tests/it/ecosystem.rs
+++ b/locator/tests/it/ecosystem.rs
@@ -1,4 +1,7 @@
-use locator::{Ecosystem, EcosystemPrivate, EcosystemPublic};
+use std::collections::HashSet;
+
+use locator::{Ecosystem, EcosystemPrivate, EcosystemPublic, Error, ParseError};
+use maplit::hashset;
 use simple_test_case::test_case;
 
 #[test_case(Ecosystem::Archive, "archive"; "archive")]
@@ -33,7 +36,12 @@ use simple_test_case::test_case;
 #[test_case(Ecosystem::User, "user"; "user")]
 #[test]
 fn render_all(ecosystem: Ecosystem, target: &str) {
-    pretty_assertions::assert_eq!(&ecosystem.to_string(), target, "render {ecosystem:?}");
+    pretty_assertions::assert_eq!(&ecosystem.to_string(), target, "to_string {ecosystem:?}");
+    pretty_assertions::assert_eq!(ecosystem.as_str(), target, "as_str {ecosystem:?}");
+    pretty_assertions::assert_eq!(ecosystem.as_ref(), target, "as_ref {ecosystem:?}");
+
+    let serialized = serde_plain::to_string(&ecosystem).expect(&format!("serialize {ecosystem:?}"));
+    pretty_assertions::assert_eq!(serialized, target, "serialized {ecosystem:?}");
 }
 
 #[test_case(EcosystemPrivate::Archive, "archive"; "archive")]
@@ -44,7 +52,12 @@ fn render_all(ecosystem: Ecosystem, target: &str) {
 #[test_case(EcosystemPrivate::User, "user"; "user")]
 #[test]
 fn render_private(ecosystem: EcosystemPrivate, target: &str) {
-    pretty_assertions::assert_eq!(&ecosystem.to_string(), target, "render {ecosystem:?}");
+    pretty_assertions::assert_eq!(&ecosystem.to_string(), target, "to_string {ecosystem:?}");
+    pretty_assertions::assert_eq!(ecosystem.as_str(), target, "as_str {ecosystem:?}");
+    pretty_assertions::assert_eq!(ecosystem.as_ref(), target, "as_ref {ecosystem:?}");
+
+    let serialized = serde_plain::to_string(&ecosystem).expect(&format!("serialize {ecosystem:?}"));
+    pretty_assertions::assert_eq!(serialized, target, "serialized {ecosystem:?}");
 }
 
 #[test_case(EcosystemPublic::Bower, "bower"; "bower")]
@@ -73,7 +86,12 @@ fn render_private(ecosystem: EcosystemPrivate, target: &str) {
 #[test_case(EcosystemPublic::Url, "url"; "url")]
 #[test]
 fn render_public(ecosystem: EcosystemPublic, target: &str) {
-    pretty_assertions::assert_eq!(&ecosystem.to_string(), target, "render {ecosystem:?}");
+    pretty_assertions::assert_eq!(&ecosystem.to_string(), target, "to_string {ecosystem:?}");
+    pretty_assertions::assert_eq!(ecosystem.as_str(), target, "as_str {ecosystem:?}");
+    pretty_assertions::assert_eq!(ecosystem.as_ref(), target, "as_ref {ecosystem:?}");
+
+    let serialized = serde_plain::to_string(&ecosystem).expect(&format!("serialize {ecosystem:?}"));
+    pretty_assertions::assert_eq!(serialized, target, "serialized {ecosystem:?}");
 }
 
 #[test_case(EcosystemPublic::Bower, "bower"; "bower")]
@@ -102,7 +120,10 @@ fn render_public(ecosystem: EcosystemPublic, target: &str) {
 #[test_case(EcosystemPublic::Url, "url"; "url")]
 #[test]
 fn parse_public(ecosystem: EcosystemPublic, target: &str) {
-    let parsed = serde_plain::from_str::<EcosystemPublic>(target).expect("parse ecosystem");
+    let parsed = serde_plain::from_str::<EcosystemPublic>(target).expect("deserialize");
+    pretty_assertions::assert_eq!(parsed, ecosystem, "deserialize {ecosystem:?}");
+
+    let parsed = EcosystemPublic::parse(target).expect("parse");
     pretty_assertions::assert_eq!(parsed, ecosystem, "parse {ecosystem:?}");
 }
 
@@ -138,7 +159,10 @@ fn parse_public(ecosystem: EcosystemPublic, target: &str) {
 #[test_case(Ecosystem::User, "user"; "user")]
 #[test]
 fn parse_all(ecosystem: Ecosystem, target: &str) {
-    let parsed = serde_plain::from_str::<Ecosystem>(target).expect("parse ecosystem");
+    let parsed = serde_plain::from_str::<Ecosystem>(target).expect("deserialize");
+    pretty_assertions::assert_eq!(parsed, ecosystem, "deserialize {ecosystem:?}");
+
+    let parsed = Ecosystem::parse(target).expect("parse");
     pretty_assertions::assert_eq!(parsed, ecosystem, "parse {ecosystem:?}");
 }
 
@@ -150,8 +174,113 @@ fn parse_all(ecosystem: Ecosystem, target: &str) {
 #[test_case(EcosystemPrivate::User, "user"; "user")]
 #[test]
 fn parse_private(ecosystem: EcosystemPrivate, target: &str) {
-    let parsed = serde_plain::from_str::<EcosystemPrivate>(target).expect("parse ecosystem");
+    let parsed = serde_plain::from_str::<EcosystemPrivate>(target).expect("deserialize");
+    pretty_assertions::assert_eq!(parsed, ecosystem, "deserialize {ecosystem:?}");
+
+    let parsed = EcosystemPrivate::parse(target).expect("parse");
     pretty_assertions::assert_eq!(parsed, ecosystem, "parse {ecosystem:?}");
+}
+
+#[test]
+fn parse_fail_all() {
+    let parsed = Ecosystem::parse("_does_not_exist").expect_err("parse");
+    let expected = hashset! {
+        String::from("archive"),
+        String::from("bower"),
+        String::from("cart"),
+        String::from("cargo"),
+        String::from("csbinary"),
+        String::from("comp"),
+        String::from("conan"),
+        String::from("conda"),
+        String::from("cpan"),
+        String::from("cran"),
+        String::from("custom"),
+        String::from("gem"),
+        String::from("git"),
+        String::from("go"),
+        String::from("hackage"),
+        String::from("hex"),
+        String::from("apk"),
+        String::from("deb"),
+        String::from("rpm-generic"),
+        String::from("mvn"),
+        String::from("npm"),
+        String::from("nuget"),
+        String::from("pip"),
+        String::from("pod"),
+        String::from("pub"),
+        String::from("swift"),
+        String::from("rpm"),
+        String::from("upath"),
+        String::from("url"),
+        String::from("user"),
+    };
+    let options = match parsed {
+        Error::Parse(ParseError::LiteralOneOf { options, .. }) => {
+            options.into_iter().collect::<HashSet<_>>()
+        }
+        _ => panic!("expected `Error::Parse(ParseError::LiteralOneOf {{ .. }})`, got: {parsed:?}"),
+    };
+    pretty_assertions::assert_eq!(options, expected);
+}
+
+#[test]
+fn parse_fail_private() {
+    let parsed = EcosystemPrivate::parse("_does_not_exist").expect_err("parse");
+    let expected = hashset! {
+        String::from("archive"),
+        String::from("csbinary"),
+        String::from("custom"),
+        String::from("rpm"),
+        String::from("upath"),
+        String::from("user"),
+    };
+    let options = match parsed {
+        Error::Parse(ParseError::LiteralOneOf { options, .. }) => {
+            options.into_iter().collect::<HashSet<_>>()
+        }
+        _ => panic!("expected `Error::Parse(ParseError::LiteralOneOf {{ .. }})`, got: {parsed:?}"),
+    };
+    pretty_assertions::assert_eq!(options, expected);
+}
+
+#[test]
+fn parse_fail_public() {
+    let parsed = EcosystemPublic::parse("_does_not_exist").expect_err("parse");
+    let expected = hashset! {
+        String::from("bower"),
+        String::from("cart"),
+        String::from("cargo"),
+        String::from("comp"),
+        String::from("conan"),
+        String::from("conda"),
+        String::from("cpan"),
+        String::from("cran"),
+        String::from("gem"),
+        String::from("git"),
+        String::from("go"),
+        String::from("hackage"),
+        String::from("hex"),
+        String::from("apk"),
+        String::from("deb"),
+        String::from("rpm-generic"),
+        String::from("mvn"),
+        String::from("npm"),
+        String::from("nuget"),
+        String::from("pip"),
+        String::from("pod"),
+        String::from("pub"),
+        String::from("swift"),
+        String::from("url"),
+    };
+    let options = match parsed {
+        Error::Parse(ParseError::LiteralOneOf { options, .. }) => {
+            options.into_iter().collect::<HashSet<_>>()
+        }
+        _ => panic!("expected `Error::Parse(ParseError::LiteralOneOf {{ .. }})`, got: {parsed:?}"),
+    };
+    pretty_assertions::assert_eq!(options, expected);
 }
 
 #[test]
@@ -236,4 +365,107 @@ fn iter_private() {
     ];
     let iterated = EcosystemPrivate::iter().collect::<Vec<_>>();
     pretty_assertions::assert_eq!(iterated, expected);
+}
+
+// Can't use the nice `test_case` macro here since these are all distinct types;
+// the following is basically a more verbose recreation of it.
+pub mod struct_variants {
+    use locator::{Error, ParseError, ecosystems};
+
+    #[duplicate::duplicate_item(
+        _name _rendered _test_name;
+        [ ecosystems::Archive ] [ "archive" ] [ render_archive ];
+        [ ecosystems::Bower ] [ "bower" ] [ render_bower ];
+        [ ecosystems::Cart ] [ "cart" ] [ render_cart ];
+        [ ecosystems::Cargo ] [ "cargo" ] [ render_cargo ];
+        [ ecosystems::CodeSentry ] [ "csbinary" ] [ render_code_sentry ];
+        [ ecosystems::Comp ] [ "comp" ] [ render_comp ];
+        [ ecosystems::Conan ] [ "conan" ] [ render_conan ];
+        [ ecosystems::Conda ] [ "conda" ] [ render_conda ];
+        [ ecosystems::Cpan ] [ "cpan" ] [ render_cpan ];
+        [ ecosystems::Cran ] [ "cran" ] [ render_cran ];
+        [ ecosystems::Custom ] [ "custom" ] [ render_custom ];
+        [ ecosystems::Gem ] [ "gem" ] [ render_gem ];
+        [ ecosystems::Git ] [ "git" ] [ render_git ];
+        [ ecosystems::Go ] [ "go" ] [ render_go ];
+        [ ecosystems::Hackage ] [ "hackage" ] [ render_hackage ];
+        [ ecosystems::Hex ] [ "hex" ] [ render_hex ];
+        [ ecosystems::LinuxAlpine ] [ "apk" ] [ render_linux_alpine ];
+        [ ecosystems::LinuxDebian ] [ "deb" ] [ render_linux_debian ];
+        [ ecosystems::LinuxRpm ] [ "rpm-generic" ] [ render_linux_rpm ];
+        [ ecosystems::Maven ] [ "mvn" ] [ render_maven ];
+        [ ecosystems::Npm ] [ "npm" ] [ render_npm ];
+        [ ecosystems::Nuget ] [ "nuget" ] [ render_nuget ];
+        [ ecosystems::Pip ] [ "pip" ] [ render_pip ];
+        [ ecosystems::Pod ] [ "pod" ] [ render_pod ];
+        [ ecosystems::Pub ] [ "pub" ] [ render_dart ];
+        [ ecosystems::Swift ] [ "swift" ] [ render_swift ];
+        [ ecosystems::Rpm ] [ "rpm" ] [ render_rpm ];
+        [ ecosystems::UnresolvedPath ] [ "upath" ] [ render_unresolved_path ];
+        [ ecosystems::Url ] [ "url" ] [ render_url ];
+        [ ecosystems::User ] [ "user" ] [ render_user ];
+    )]
+    #[test]
+    fn _test_name() {
+        let name = _name;
+        let rendered = _rendered;
+        pretty_assertions::assert_eq!(&name.to_string(), rendered, "to_string {name:?}");
+        pretty_assertions::assert_eq!(name.as_str(), rendered, "as_str {name:?}");
+        pretty_assertions::assert_eq!(name.as_ref(), rendered, "as_ref {name:?}");
+
+        let serialized = serde_plain::to_string(&name).expect(&format!("serialize {name:?}"));
+        pretty_assertions::assert_eq!(serialized, rendered, "serialized {name:?}");
+    }
+
+    #[duplicate::duplicate_item(
+        _name _rendered _test_name;
+        [ ecosystems::Archive ] [ "archive" ] [ parse_archive ];
+        [ ecosystems::Bower ] [ "bower" ] [ parse_bower ];
+        [ ecosystems::Cart ] [ "cart" ] [ parse_cart ];
+        [ ecosystems::Cargo ] [ "cargo" ] [ parse_cargo ];
+        [ ecosystems::CodeSentry ] [ "csbinary" ] [ parse_code_sentry ];
+        [ ecosystems::Comp ] [ "comp" ] [ parse_comp ];
+        [ ecosystems::Conan ] [ "conan" ] [ parse_conan ];
+        [ ecosystems::Conda ] [ "conda" ] [ parse_conda ];
+        [ ecosystems::Cpan ] [ "cpan" ] [ parse_cpan ];
+        [ ecosystems::Cran ] [ "cran" ] [ parse_cran ];
+        [ ecosystems::Custom ] [ "custom" ] [ parse_custom ];
+        [ ecosystems::Gem ] [ "gem" ] [ parse_gem ];
+        [ ecosystems::Git ] [ "git" ] [ parse_git ];
+        [ ecosystems::Go ] [ "go" ] [ parse_go ];
+        [ ecosystems::Hackage ] [ "hackage" ] [ parse_hackage ];
+        [ ecosystems::Hex ] [ "hex" ] [ parse_hex ];
+        [ ecosystems::LinuxAlpine ] [ "apk" ] [ parse_linux_alpine ];
+        [ ecosystems::LinuxDebian ] [ "deb" ] [ parse_linux_debian ];
+        [ ecosystems::LinuxRpm ] [ "rpm-generic" ] [ parse_linux_rpm ];
+        [ ecosystems::Maven ] [ "mvn" ] [ parse_maven ];
+        [ ecosystems::Npm ] [ "npm" ] [ parse_npm ];
+        [ ecosystems::Nuget ] [ "nuget" ] [ parse_nuget ];
+        [ ecosystems::Pip ] [ "pip" ] [ parse_pip ];
+        [ ecosystems::Pod ] [ "pod" ] [ parse_pod ];
+        [ ecosystems::Pub ] [ "pub" ] [ parse_dart ];
+        [ ecosystems::Swift ] [ "swift" ] [ parse_swift ];
+        [ ecosystems::Rpm ] [ "rpm" ] [ parse_rpm ];
+        [ ecosystems::UnresolvedPath ] [ "upath" ] [ parse_unresolved_path ];
+        [ ecosystems::Url ] [ "url" ] [ parse_url ];
+        [ ecosystems::User ] [ "user" ] [ parse_user ];
+    )]
+    #[test]
+    fn _test_name() {
+        let input = _rendered;
+        _name::parse(input).expect(&format!("parse {input:?}"));
+        _name::try_from(input).expect(&format!("try_from {input:?}"));
+        _name::try_from(String::from(input)).expect(&format!("try_from_string {input:?}"));
+        _name::try_from(&String::from(input)).expect(&format!("try_from_refstring {input:?}"));
+        serde_plain::from_str::<_name>(input).expect(&format!("deserialize {input:?}"));
+
+        let parsed = _name::parse("_does_not_exist").expect_err(&format!("parse nonexistent"));
+        let expected = match parsed {
+            Error::Parse(ParseError::LiteralExact { expected, .. }) => expected,
+            _ => panic!(
+                "expected `Error::Parse(ParseError::LiteralExact {{ .. }})`, got: {parsed:?}"
+            ),
+        };
+        pretty_assertions::assert_eq!(expected, input);
+    }
 }

--- a/locator/tests/it/locator_package.rs
+++ b/locator/tests/it/locator_package.rs
@@ -98,6 +98,14 @@ fn roundtrip_serialization() {
 }
 
 #[test]
+fn roundtrip_fromparts() {
+    let input = package!(org 1 => Custom, "foo");
+    let parts = input.clone().into_parts();
+    let constructed = PackageLocator::from_parts(parts);
+    assert_eq!(input, constructed);
+}
+
+#[test]
 fn serde_deserialization() {
     #[derive(Debug, Deserialize, PartialEq)]
     struct Test {

--- a/locator/tests/it/locator_strict.rs
+++ b/locator/tests/it/locator_strict.rs
@@ -141,6 +141,14 @@ fn roundtrip_serialization() {
 }
 
 #[test]
+fn roundtrip_fromparts() {
+    let input = strict!(org 1 => Custom, "foo", "bar");
+    let parts = input.clone().into_parts();
+    let constructed = StrictLocator::from_parts(parts);
+    assert_eq!(input, constructed);
+}
+
+#[test]
 fn serde_deserialization() {
     #[derive(Debug, Deserialize, PartialEq)]
     struct Test {

--- a/locator/tests/it/locator_t.rs
+++ b/locator/tests/it/locator_t.rs
@@ -158,6 +158,14 @@ fn roundtrip_serialization() {
 }
 
 #[test]
+fn roundtrip_fromparts() {
+    let input = locator!(org 1 => Custom, "foo", "bar");
+    let parts = input.clone().into_parts();
+    let constructed = Locator::from_parts(parts);
+    assert_eq!(input, constructed);
+}
+
+#[test]
 fn serde_deserialization() {
     #[derive(Debug, Deserialize, PartialEq)]
     struct Test {
@@ -274,12 +282,12 @@ proptest! {
 
 /// Regular expression that matches any unicode string that is:
 /// - Prefixed with `custom+`
-/// - Contains zero or more digits
+/// - Contains zero or more digits that do not begin with `0`
 /// - Contains a literal `/`
 /// - Contains at least one character that is not a control character, space, or the literal `$`
 /// - Contains a literal `$`
 /// - Contains at least one character that is not a control character, space, or the literal `$`
-const VALID_INPUTS_CUSTOM_WITH_ORG: &str = r"custom\+\d*/[^\pC\s$]+\$[^\pC\s$]+";
+const VALID_INPUTS_CUSTOM_WITH_ORG: &str = r"custom\+([1-9]\d*)?/[^\pC\s$]+\$[^\pC\s$]+";
 
 proptest! {
     /// Tests randomly generated strings that match the provided regular expression against the parser.

--- a/locator/tests/it/locator_t.rs
+++ b/locator/tests/it/locator_t.rs
@@ -197,6 +197,32 @@ fn promotes_strict() {
 }
 
 #[test]
+fn build_with_macro() {
+    locator::locator!(org 10 => Npm, "lodash", "1.0");
+    locator::locator!(Npm, "lodash", "1.0");
+    locator::locator!(Npm, "lodash");
+}
+
+#[test]
+fn build_with_builder() {
+    locator::Locator::builder()
+        .organization(10)
+        .ecosystem(Ecosystem::Npm)
+        .package("lodash")
+        .revision(locator::revision!("1.0"))
+        .build();
+    locator::Locator::builder()
+        .ecosystem(Ecosystem::Npm)
+        .package("lodash")
+        .revision(locator::revision!("1.0"))
+        .build();
+    locator::Locator::builder()
+        .ecosystem(Ecosystem::Npm)
+        .package("lodash")
+        .build();
+}
+
+#[test]
 fn ordering() {
     let locators = vec![
         "git+github.com/foo/bar",


### PR DESCRIPTION
# Overview

Extends the parsers:
- struct variants of `Ecosystem`, e.g. `locator::ecosystems::Npm`, actually parse now.
  - Previously, they failed to parse with an error like `"" expected for unit struct`.
  - We missed this because there were no tests for struct variants; they now exist.
- enum variants of `Ecosystem` now provide methods for converting to and from strings:
  - Previously, we relied on `serde_plain` to generate `Display`, but had no way of parsing a string to an `Ecosystem` without going through `serde`.
- Implement widespread implementations to and from strings:
  - `std::fmt::Display`, `AsRef<str>`, and `pub fn as_str(&self) -> &str` for each struct and enum.
  - `TryFrom<String>`, `TryFrom<&String>`, `TryFrom<&str>` for each struct and enum.

In addition, I made `from_parts` and `into_parts` public so that callers can more easily construct/mutate locators.

## Acceptance criteria

We can now parse and render `Ecosystem` to and from string without requiring going through serde.

## Testing plan

Added lots of automated tests, using those.

## Metrics

None

## Risks

None

## References

Part of the new fetcher work.

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
