### PR TITLE
[No Ticket] Add url-private fetcher value

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -194,6 +194,11 @@ pub enum Fetcher {
     #[strum(serialize = "url")]
     Url,
 
+    /// Refers to an uploaded archive at a private URL.
+    #[strum(serialize = "url-private")]
+    #[serde(rename = "url-private")]
+    UrlPrivate,
+
     /// An unresolved path dependency.
     #[strum(serialize = "upath")]
     #[serde(rename = "upath")]


### PR DESCRIPTION
# Overview
While backfilling dependencies from DepLocks into Sparkle, I found that Sparkle was rejecting deps with `url-private` locators because this package did not have that value registered.

This PR adds `url-private`. No other merges that added fetcher values had tests, so I didn't add any either.

## Acceptance criteria
- `url-private` is considered legit
- Sparkle stops erroring from locators with this fetcher once it has this change

## Testing plan
I didn't test it lol.

## Metrics
Backfills stop erroring on this type of locator.

## Risks
No real risk, I don't think.

## References

_Add links to any referenced GitHub issues, Zendesk tickets, Jira tickets, Slack threads, etc._

_Example:_

- _[ANE-123](https://fossa.atlassian.net/browse/ANE-123): Implement X._

## Checklist

- [ ] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
