### PR TITLE
Purl to v3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ nom = "8.0.0"
 derive_more = { version = "2.0.1", features = ["full"] }
 tracing = "0.1.41"
 derivative = "2.2.0"
+purl = { version = "0.1.6", features = ["serde"] }
 
 [dev-dependencies]
 assert_matches = "1.5.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "locator"
-version = "3.0.5"
+version = "3.1.0"
 edition = "2024"
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "locator"
-version = "3.1.0"
+version = "5.0.0"
 edition = "2024"
 
 [dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,7 @@ mod error;
 mod locator;
 mod locator_package;
 mod locator_strict;
+pub mod purl;
 
 pub use error::*;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -141,7 +141,7 @@ pub enum Fetcher {
 
     /// Interacts with Maven.
     #[strum(serialize = "mvn")]
-    #[serde(alias = "mvn")]
+    #[serde(rename = "mvn", alias = "maven")]
     Maven,
 
     /// Interacts with NPM.
@@ -174,7 +174,7 @@ pub enum Fetcher {
 
     /// Interacts with projects hosted on SourceForge.
     #[strum(serialize = "sourceforge")]
-    #[serde(alias = "sourceforge")]
+    #[serde(rename = "sourceforge", alias = "source_forge")]
     SourceForge,
 
     /// Interacts with code snippets on StackOverflow.
@@ -183,7 +183,7 @@ pub enum Fetcher {
     /// So `stackoverflow+66875589$1` is the first answer to the question found at
     /// https://stackoverflow.com/questions/66875589
     #[strum(serialize = "stackoverflow")]
-    #[serde(alias = "stackoverflow")]
+    #[serde(rename = "stackoverflow", alias = "stack_overflow")]
     StackOverflow,
 
     /// Interact with Swift's package manager.

--- a/src/purl.rs
+++ b/src/purl.rs
@@ -227,7 +227,7 @@ impl Purl {
     fn to_default_locator(&self) -> Result<Locator, Error> {
         let fetcher = self.fetcher()?;
         let package = self.name();
-        let revision = self.version().map(crate::Revision::from);
+        let revision = self.version().and_then(revision);
 
         Ok(Locator::builder()
             .fetcher(fetcher)
@@ -235,6 +235,18 @@ impl Purl {
             .maybe_revision(revision)
             .build())
     }
+}
+
+/// Build the revision component for a converted purl.
+///
+/// v4 built revisions with the fallible `Revision::parse`, which fails only on
+/// input that is empty after trimming; this reproduces that behaviour with
+/// v3's infallible conversion so that purls without a meaningful version
+/// (including apk/deb/rpm, whose joined `arch#version` string can be empty)
+/// yield no revision rather than `Some(Opaque(""))`.
+fn revision(version: &str) -> Option<crate::Revision> {
+    let version = version.trim();
+    (!version.is_empty()).then(|| crate::Revision::from(version))
 }
 
 /// Options for converting a PURL to a Locator.
@@ -290,6 +302,11 @@ mod tests {
         "apk_without_distro"
     )]
     #[test_case(
+        "pkg:apk/alpine/curl",
+        "apk+curl#alpine";
+        "apk_no_version_no_arch"
+    )]
+    #[test_case(
         "pkg:maven/org.apache.xmlgraphics/batik-anim@1.9.1",
         "mvn+org.apache.xmlgraphics:batik-anim$1.9.1";
         "maven_basic"
@@ -331,6 +348,7 @@ mod tests {
         "npm+@angular/animation$12.3.1";
         "npm_with_namespace"
     )]
+    #[test_case("pkg:npm/foobar@%20", "npm+foobar"; "npm_whitespace_version")]
     #[test_case(
         "pkg:nuget/EnterpriseLibrary.Common@6.0.1304",
         "nuget+EnterpriseLibrary.Common$6.0.1304";
@@ -394,6 +412,11 @@ mod tests {
         "rpm_without_distro"
     )]
     #[test_case(
+        "pkg:rpm/fedora/curl?distro=fedora-25",
+        "rpm-generic+curl#fedora#25";
+        "rpm_no_version_no_arch"
+    )]
+    #[test_case(
         "pkg:deb/debian/dpkg@1.19.0.4?arch=amd64&distro=stretch",
         "deb+dpkg#debian#stretch$amd64#1.19.0.4";
         "deb_basic"
@@ -402,6 +425,11 @@ mod tests {
         "pkg:deb/ubuntu/adduser@3.118ubuntu2?distro=ubuntu-20.04&arch=amd64",
         "deb+adduser#ubuntu#20.04$amd64#3.118ubuntu2";
         "deb_with_vendor_version"
+    )]
+    #[test_case(
+        "pkg:deb/debian/dpkg?distro=stretch",
+        "deb+dpkg#debian#stretch";
+        "deb_no_version_no_arch"
     )]
     #[test_case(
         "pkg:sourceforge/dex-os@1.0",

--- a/src/purl.rs
+++ b/src/purl.rs
@@ -239,11 +239,12 @@ impl Purl {
 
 /// Build the revision component for a converted purl.
 ///
-/// v4 built revisions with the fallible `Revision::parse`, which fails only on
-/// input that is empty after trimming; this reproduces that behaviour with
-/// v3's infallible conversion so that purls without a meaningful version
-/// (including apk/deb/rpm, whose joined `arch#version` string can be empty)
-/// yield no revision rather than `Some(Opaque(""))`.
+/// Purls without a meaningful version must yield no revision rather than
+/// `Some(Opaque(""))`, which would render as a trailing `$` and fail to
+/// round-trip through `Locator::parse`. For example, `pkg:apk/alpine/curl`
+/// has no version and no `arch` qualifier, so apk's joined `arch#version`
+/// revision string is empty: the locator must be `apk+curl#alpine`,
+/// not `apk+curl#alpine$`.
 fn revision(version: &str) -> Option<crate::Revision> {
     let version = version.trim();
     (!version.is_empty()).then(|| crate::Revision::from(version))

--- a/src/purl.rs
+++ b/src/purl.rs
@@ -1,0 +1,614 @@
+//! Logic for converting Package URLs (PURLs) to [`Locators`](Locator).
+//!
+//! See the [Package URL specification](https://github.com/package-url/purl-spec).
+//!
+//! Exposes the [`Purl`] struct, which is a thin wrapper around [`purl::GenericPurl`].
+//! This struct can be converted to a [`Locator`] via the [`TryFrom`] trait.
+//!
+//! Not all PURL types are supported. Unsupported PURLs will return an
+//! [`Error::UnsupportedPurl`] error. See the [`Locator::try_from`] impl in this
+//! module for the full list of supported PURL types.
+
+use std::str::FromStr;
+
+use derive_more::{Deref, DerefMut, From};
+use purl::GenericPurl;
+use thiserror::Error;
+
+use crate::Locator;
+
+mod apk;
+mod bitbucket;
+mod cocoapods;
+mod composer;
+mod cpan;
+mod deb;
+mod gitee;
+mod github;
+mod gitlab;
+mod golang;
+mod googlesource;
+mod maven;
+mod npm;
+mod rpm;
+mod sourceforge;
+mod swift;
+
+/// A Package URL (PURL).
+///
+/// A package URL is a standardized way to identify and locate software packages.
+/// It's very similar to a locator, but has a different format and set of conventions.
+///
+/// Read more about PURLs in the [spec](https://github.com/package-url/purl-spec).
+///
+/// This struct is a thin wrapper around [`purl::GenericPurl`], which is an
+/// external crate implementation of the PURL spec, and may have its own
+/// limitations.
+///
+/// The main purpose of this struct is to provide a way to convert a PURL
+/// to a [`Locator`]. You can start by parsing a PURL from a string:
+/// ```rust
+/// # use locator::purl::Purl;
+/// # use std::str::FromStr;
+/// let purl = Purl::from_str("pkg:npm/lodash@4.17.21").unwrap();
+/// ```
+/// Then convert it to a locator:
+/// ```rust
+/// # use locator::purl::Purl;
+/// # use locator::Locator;
+/// # use std::str::FromStr;
+/// # use std::convert::TryFrom;
+/// # let purl = Purl::from_str("pkg:npm/lodash@4.17.21").unwrap();
+/// let locator = Locator::try_from(purl).unwrap();
+/// ```
+///
+/// Another way to convert is via the [`Purl::try_into_locator_with_options`]
+/// which allows providing custom [`ConversionOptions`] that can modify the
+/// behaviour of the conversion for specific ecosystems:
+/// ```rust
+/// # use locator::purl::{Purl, ConversionOptions};
+/// # use locator::Locator;
+/// # use std::str::FromStr;
+/// // We're missing the namespace in this PURL, but we can provide a fallback.
+/// let purl = Purl::from_str("pkg:composer/laravel@5.5.0").unwrap();
+/// let options = ConversionOptions {
+///     fallback_composer_namespace: Some("vendor".to_string()),
+///     ..Default::default()
+/// };
+/// let locator = purl.try_into_locator_with_options(options).unwrap();
+/// ```
+///
+/// All of these operations can fail. See [`purl::ParseError`] for PURL parsing
+/// errors and [`Error`] for conversion errors.
+#[derive(Clone, Debug, Eq, Hash, PartialEq, PartialOrd, Ord, Deref, DerefMut, From)]
+pub struct Purl(GenericPurl<String>);
+
+impl FromStr for Purl {
+    type Err = purl::ParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let generic_purl = GenericPurl::from_str(s)?;
+        Ok(Purl(generic_purl))
+    }
+}
+
+/// Try to convert a Purl to a Locator. This is a fallible operation, see
+/// the [`Error`] enum for possible errors.
+impl TryFrom<Purl> for Locator {
+    type Error = Error;
+
+    fn try_from(purl: Purl) -> Result<Self, Self::Error> {
+        purl.try_into_locator_with_options(ConversionOptions::default())
+    }
+}
+
+impl Purl {
+    /// Determines the corresponding [`Fetcher`](crate::Fetcher) for this PURL.
+    /// This is based on the PURL package type.
+    ///
+    /// E.g.
+    /// ```rust
+    /// # use locator::purl::Purl;
+    /// # use std::str::FromStr;
+    /// let purl = Purl::from_str("pkg:npm/lodash@4.17.21").unwrap();
+    /// let fetcher = purl.fetcher().unwrap();
+    /// assert_eq!(fetcher, locator::Fetcher::Npm);
+    /// ```
+    ///
+    /// This is a fallible operation, see the [`Error`] enum for possible errors.
+    pub fn fetcher(&self) -> Result<crate::Fetcher, Error> {
+        let package_type = self.package_type().to_string();
+
+        macro_rules! unsupported {
+            () => {
+                Err(Error::UnsupportedPurl(package_type.clone()))
+            };
+        }
+
+        match package_type.as_str() {
+            "alpm" => unsupported!(),
+            "apk" => Ok(crate::Fetcher::LinuxAlpine),
+            "bitbucket" => Ok(crate::Fetcher::Git),
+            "bower" => unsupported!(),
+            "cargo" => Ok(crate::Fetcher::Cargo),
+            "carthage" => unsupported!(),
+            "cocoapods" => Ok(crate::Fetcher::Pod),
+            "composer" => Ok(crate::Fetcher::Comp),
+            "conan" => unsupported!(),
+            "conda" => unsupported!(),
+            "cpan" => Ok(crate::Fetcher::Cpan),
+            "cran" => Ok(crate::Fetcher::Cran),
+            "deb" => Ok(crate::Fetcher::LinuxDebian),
+            "gem" => Ok(crate::Fetcher::Gem),
+            "generic" => unsupported!(),
+            "github" => Ok(crate::Fetcher::Git),
+            "gitee" => Ok(crate::Fetcher::Git),
+            "gitlab" => Ok(crate::Fetcher::Git),
+            "golang" => Ok(crate::Fetcher::Go),
+            "googlesource" => Ok(crate::Fetcher::Git),
+            "gradle" => unsupported!(),
+            "hackage" => Ok(crate::Fetcher::Hackage),
+            "hex" => Ok(crate::Fetcher::Hex),
+            "maven" => Ok(crate::Fetcher::Maven),
+            "npm" => Ok(crate::Fetcher::Npm),
+            "nuget" => Ok(crate::Fetcher::Nuget),
+            "pub" => Ok(crate::Fetcher::Pub),
+            "pypi" => Ok(crate::Fetcher::Pip),
+            "rpm" => Ok(crate::Fetcher::LinuxRpm),
+            "sourceforge" => Ok(crate::Fetcher::SourceForge),
+            "stackoverflow" => Ok(crate::Fetcher::StackOverflow),
+            "swift" => Ok(crate::Fetcher::Swift),
+            _ => unsupported!(),
+        }
+    }
+
+    /// Converts a [`Purl`] into a [`Locator`] using the provided [`ConversionOptions`].
+    ///
+    /// The conversion options allow customizing the conversion process for
+    /// specific ecosystems. If you don't need any custom options, you can use
+    /// the default conversion via the [`TryFrom`] trait implementation.
+    ///
+    /// This is a fallible operation, see the [`Error`] enum for possible errors.
+    pub fn try_into_locator_with_options(
+        self,
+        options: ConversionOptions,
+    ) -> Result<Locator, Error> {
+        let package_type = self.package_type().to_string();
+
+        macro_rules! unsupported {
+            () => {
+                Err(Error::UnsupportedPurl(package_type.clone()))
+            };
+        }
+
+        match package_type.as_str() {
+            "alpm" => unsupported!(),
+            "apk" => apk::purl_to_locator(self),
+            "bitbucket" => bitbucket::purl_to_locator(self),
+            "bower" => unsupported!(),
+            "cargo" => self.to_default_locator(),
+            "carthage" => unsupported!(),
+            "cocoapods" => cocoapods::purl_to_locator(self),
+            "composer" => composer::purl_to_locator(self, options),
+            "conan" => unsupported!(),
+            "conda" => unsupported!(),
+            "cpan" => cpan::purl_to_locator(self),
+            "cran" => self.to_default_locator(),
+            "deb" => deb::purl_to_locator(self, options),
+            "gem" => self.to_default_locator(),
+            "generic" => unsupported!(),
+            "github" => github::purl_to_locator(self),
+            "gitee" => gitee::purl_to_locator(self),
+            "gitlab" => gitlab::purl_to_locator(self),
+            "golang" => golang::purl_to_locator(self),
+            "googlesource" => googlesource::purl_to_locator(self),
+            "gradle" => unsupported!(),
+            "hackage" => self.to_default_locator(),
+            "hex" => self.to_default_locator(),
+            "maven" => maven::purl_to_locator(self),
+            "npm" => npm::purl_to_locator(self),
+            "nuget" => self.to_default_locator(),
+            "pub" => self.to_default_locator(),
+            "pypi" => self.to_default_locator(),
+            "rpm" => rpm::purl_to_locator(self),
+            "sourceforge" => sourceforge::purl_to_locator(self),
+            "stackoverflow" => self.to_default_locator(),
+            "swift" => swift::purl_to_locator(self, options),
+            _ => unsupported!(),
+        }
+    }
+
+    /// Converts a [`Purl`] into a [`Locator`] using a default conversion method.
+    /// This should be left private while [`Purl::try_into_locator_with_options`]
+    /// is the preferred public method for conversion because most ecosystems
+    /// require special handling that the default method does not provide.
+    ///
+    /// This is a fallible operation, see the [`Error`] enum for possible errors.
+    fn to_default_locator(&self) -> Result<Locator, Error> {
+        let fetcher = self.fetcher()?;
+        let package = self.name();
+        let revision = self.version().map(crate::Revision::from);
+
+        Ok(Locator::builder()
+            .fetcher(fetcher)
+            .package(package)
+            .maybe_revision(revision)
+            .build())
+    }
+}
+
+/// Options for converting a PURL to a Locator.
+///
+/// These options customize the behaviour of the conversation process for
+/// specific ecosystems.
+///
+/// The `fallback_*` fields provide default values to use when the corresponding
+/// parts are missing from the PURL. It's useful to provide these when you want
+/// the conversation to succeed even if the PURL is incomplete.
+#[derive(Debug, Clone, Default)]
+pub struct ConversionOptions {
+    /// Fallback Debian distro name to use if the PURL namespace is missing.
+    pub fallback_deb_distro_name: Option<String>,
+    /// Fallback Debian distro version to use if the `distro` qualifier is missing.
+    pub fallback_deb_distro_version: Option<String>,
+    /// Fallback Debian architecture to use if the `arch` qualifier is missing.
+    pub fallback_deb_arch: Option<String>,
+    /// Fallback Swift namespace to use if the PURL namespace is missing.
+    pub fallback_swift_namespace: Option<String>,
+    /// Fallback Composer namespace to use if the PURL namespace is missing.
+    pub fallback_composer_namespace: Option<String>,
+}
+
+/// Errors that can occur when converting a PURL to a locator.
+#[derive(Error, Debug)]
+pub enum Error {
+    /// The PURL type is not supported for conversion to a locator.
+    #[error("unsupported purl: {0}")]
+    UnsupportedPurl(String),
+    /// A required qualifier is missing from the PURL.
+    #[error("missing required qualifier: {0}")]
+    MissingQualifier(String),
+    /// A required namespace is missing from the PURL.
+    #[error("missing required namespace: {0}")]
+    MissingNamespace(String),
+}
+
+#[cfg(test)]
+mod tests {
+    use simple_test_case::test_case;
+
+    use super::*;
+
+    #[test_case(
+        "pkg:apk/alpine/alpine-keys@1.1-r0?distro=3.4.6",
+        "apk+alpine-keys#alpine#3.4.6$1.1-r0";
+        "apk_with_distro"
+    )]
+    #[test_case(
+        "pkg:apk/alpine/alpine-baselayout-data@3.4.0-r0",
+        "apk+alpine-baselayout-data#alpine$3.4.0-r0";
+        "apk_without_distro"
+    )]
+    #[test_case(
+        "pkg:maven/org.apache.xmlgraphics/batik-anim@1.9.1",
+        "mvn+org.apache.xmlgraphics:batik-anim$1.9.1";
+        "maven_basic"
+    )]
+    #[test_case(
+        "pkg:maven/org.apache.xmlgraphics/batik-anim@1.9.1?repository_url=repo.spring.io%2Frelease",
+        "mvn+repo.spring.io/release:org.apache.xmlgraphics:batik-anim$1.9.1";
+        "maven_with_repository_url"
+    )]
+    #[test_case("pkg:cargo/structopt@0.3.11", "cargo+structopt$0.3.11"; "cargo_basic")]
+    #[test_case("pkg:composer/laravel/laravel@5.5.0", "comp+laravel/laravel$5.5.0"; "composer_basic")]
+    #[test_case("pkg:cpan/CTDEAN/Tk-Tree@0.02", "cpan+Tk::Tree$0.02"; "cpan_with_namespace")]
+    #[test_case(
+        "pkg:cpan/Convert-ASCIINames@1.002",
+        "cpan+Convert::ASCIINames$1.002";
+        "cpan_without_namespace"
+    )]
+    #[test_case("pkg:cran/caret@6.0-88", "cran+caret$6.0-88"; "cran_basic")]
+    #[test_case(
+        "pkg:gem/ruby-advisory-db-check@0.12.4",
+        "gem+ruby-advisory-db-check$0.12.4";
+        "gem_basic"
+    )]
+    #[test_case(
+        "pkg:golang/github.com/gorilla/context@234fd47e07d1004f0aed9c",
+        "go+github.com/gorilla/context$234fd47e07d1004f0aed9c";
+        "golang_basic"
+    )]
+    #[test_case(
+        "pkg:golang/github.com/gorilla/context@234fd47e07d1004f0aed9c#api",
+        "go+github.com/gorilla/context/api$234fd47e07d1004f0aed9c";
+        "golang_with_subpath"
+    )]
+    #[test_case("pkg:hackage/a50@0.5", "hackage+a50$0.5"; "hackage_basic")]
+    #[test_case("pkg:hex/jason@1.1.2", "hex+jason$1.1.2"; "hex_basic")]
+    #[test_case("pkg:npm/foobar@12.3.1", "npm+foobar$12.3.1"; "npm_basic")]
+    #[test_case(
+        "pkg:npm/%40angular/animation@12.3.1",
+        "npm+@angular/animation$12.3.1";
+        "npm_with_namespace"
+    )]
+    #[test_case(
+        "pkg:nuget/EnterpriseLibrary.Common@6.0.1304",
+        "nuget+EnterpriseLibrary.Common$6.0.1304";
+        "nuget_basic"
+    )]
+    #[test_case("pkg:pypi/django-allauth@12.23", "pip+django-allauth$12.23"; "pypi_basic")]
+    #[test_case(
+        "pkg:pub/at_persistence_secondary_server@1.2.0",
+        "pub+at_persistence_secondary_server$1.2.0";
+        "pub_basic"
+    )]
+    #[test_case(
+        "pkg:swift/github.com/Alamofire/Alamofire@5.4.3",
+        "swift+github.com/Alamofire/Alamofire$5.4.3";
+        "swift_basic"
+    )]
+    #[test_case("pkg:cocoapods/MapsIndoors@3.24.0", "pod+MapsIndoors$3.24.0"; "cocoapods_basic")]
+    #[test_case(
+        "pkg:cocoapods/ShareKit@2.0#Twitter",
+        "pod+ShareKit/Twitter$2.0";
+        "cocoapods_with_subspec"
+    )]
+    #[test_case(
+        "pkg:github/package-url/purl-spec@244fd47e07d1004",
+        "git+github.com/package-url/purl-spec$244fd47e07d1004";
+        "github_basic"
+    )]
+    #[test_case(
+        "pkg:gitlab/NTPsec/ntpsec@1feb8f90dd30ae573bf79205af53879a6e1e60c4",
+        "git+gitlab.com/NTPsec/ntpsec$1feb8f90dd30ae573bf79205af53879a6e1e60c4";
+        "gitlab_basic"
+    )]
+    #[test_case(
+        "pkg:gitee/apache/thrift@0.11.0",
+        "git+gitee.com/apache/thrift$0.11.0";
+        "gitee_basic"
+    )]
+    #[test_case(
+        "pkg:googlesource/android/device/linaro/bootloader/edk2@aml_tz2_306503000",
+        "git+android.googlesource.com/device/linaro/bootloader/edk2$aml_tz2_306503000";
+        "googlesource_basic"
+    )]
+    #[test_case(
+        "pkg:bitbucket/birkenfeld/pygments-main@244fd47e07d1014f0aed9c",
+        "git+bitbucket.org/birkenfeld/pygments-main$244fd47e07d1014f0aed9c";
+        "bitbucket_basic"
+    )]
+    #[test_case(
+        "pkg:rpm/fedora/curl@7.50.3-1.fc25?arch=i386&distro=fedora-25",
+        "rpm-generic+curl#fedora#25$i386#0:7.50.3-1.fc25";
+        "rpm_basic"
+    )]
+    #[test_case(
+        "pkg:rpm/fedora/curl@7.50.3-1.fc25?epoch=1&arch=i386&distro=fedora-25",
+        "rpm-generic+curl#fedora#25$i386#1:7.50.3-1.fc25";
+        "rpm_with_epoch"
+    )]
+    #[test_case(
+        "pkg:rpm/fedora/curl@7.50.3-1.fc25?epoch=1&arch=i386",
+        "rpm-generic+curl#fedora#latest$i386#1:7.50.3-1.fc25";
+        "rpm_without_distro"
+    )]
+    #[test_case(
+        "pkg:deb/debian/dpkg@1.19.0.4?arch=amd64&distro=stretch",
+        "deb+dpkg#debian#stretch$amd64#1.19.0.4";
+        "deb_basic"
+    )]
+    #[test_case(
+        "pkg:deb/ubuntu/adduser@3.118ubuntu2?distro=ubuntu-20.04&arch=amd64",
+        "deb+adduser#ubuntu#20.04$amd64#3.118ubuntu2";
+        "deb_with_vendor_version"
+    )]
+    #[test_case(
+        "pkg:sourceforge/dex-os@1.0",
+        "sourceforge+dex-os$1.0";
+        "sourceforge_without_namespace"
+    )]
+    #[test_case(
+        "pkg:sourceforge/intel-iscsi/ost@3.0.0",
+        "sourceforge+intel-iscsi$3.0.0";
+        "sourceforge_with_namespace"
+    )]
+    #[test_case("pkg:stackoverflow/48810170@1", "stackoverflow+48810170$1"; "stackoverflow_basic")]
+    #[test]
+    fn purl_to_locator(purl_str: &str, locator_str: &str) {
+        let purl = Purl::from_str(purl_str).expect("parse purl");
+        let locator = Locator::try_from(purl).expect("convert to locator");
+        assert_eq!(locator.to_string(), locator_str);
+    }
+
+    #[test_case(
+        None,
+        None,
+        None,
+        "pkg:deb/ubuntu/adduser@3.118ubuntu2?distro=ubuntu-20.04&arch=amd64",
+        "deb+adduser#ubuntu#20.04$amd64#3.118ubuntu2";
+        "no_options"
+    )]
+    #[test_case(
+        None,
+        Some("unknown"),
+        None,
+        "pkg:deb/ubuntu/adduser@3.118ubuntu2?arch=amd64",
+        "deb+adduser#ubuntu#unknown$amd64#3.118ubuntu2";
+        "fallback_version"
+    )]
+    #[test_case(
+        Some("debian"),
+        Some("unknown"),
+        None,
+        "pkg:deb/adduser@3.118ubuntu2?arch=amd64",
+        "deb+adduser#debian#unknown$amd64#3.118ubuntu2";
+        "fallback_name_and_version"
+    )]
+    #[test_case(
+        None,
+        None,
+        Some("unknown"),
+        "pkg:deb/ubuntu/adduser@3.118ubuntu2?distro=ubuntu-20.04",
+        "deb+adduser#ubuntu#20.04$unknown#3.118ubuntu2";
+        "fallback_arch"
+    )]
+    #[test_case(
+        Some("debian"),
+        Some("unknown"),
+        None,
+        "pkg:deb/ubuntu/adduser@3.118ubuntu2?arch=amd64&distro=ubuntu-20.04",
+        "deb+adduser#ubuntu#20.04$amd64#3.118ubuntu2";
+        "unnecesssary_fallback_name_and_version"
+    )]
+    #[test_case(
+        None,
+        None,
+        Some("unknown"),
+        "pkg:deb/ubuntu/adduser@3.118ubuntu2?distro=ubuntu-20.04&arch=amd64",
+        "deb+adduser#ubuntu#20.04$amd64#3.118ubuntu2";
+        "unnecesssary_fallback_arch"
+    )]
+    #[test]
+    fn deb_options(
+        fallback_name: Option<&str>,
+        fallback_version: Option<&str>,
+        fallback_arch: Option<&str>,
+        purl_str: &str,
+        locator_str: &str,
+    ) {
+        let purl = Purl::from_str(purl_str).expect("parse purl");
+        let options = ConversionOptions {
+            fallback_deb_distro_name: fallback_name.map(String::from),
+            fallback_deb_distro_version: fallback_version.map(String::from),
+            fallback_deb_arch: fallback_arch.map(String::from),
+            ..Default::default()
+        };
+        let locator = purl
+            .try_into_locator_with_options(options)
+            .expect("convert to locator");
+        assert_eq!(locator.to_string(), locator_str);
+    }
+
+    #[test_case(
+        None,
+        "pkg:swift/github.com/Alamofire/Alamofire@5.4.3",
+        "swift+github.com/Alamofire/Alamofire$5.4.3";
+        "no_fallback"
+    )]
+    #[test_case(
+        Some("github.com/example"),
+        "pkg:swift/Alamofire@5.4.3",
+        "swift+github.com/example/Alamofire$5.4.3";
+        "with_fallback"
+    )]
+    #[test_case(
+        Some("github.com/example"),
+        "pkg:swift/github.com/Alamofire/Alamofire@5.4.3",
+        "swift+github.com/Alamofire/Alamofire$5.4.3";
+        "unnecessary_fallback"
+    )]
+    #[test]
+    fn swift_options(fallback_namespace: Option<&str>, purl_str: &str, locator_str: &str) {
+        let purl = Purl::from_str(purl_str).expect("parse purl");
+        let options = ConversionOptions {
+            fallback_swift_namespace: fallback_namespace.map(String::from),
+            ..Default::default()
+        };
+        let locator = purl
+            .try_into_locator_with_options(options)
+            .expect("convert to locator");
+        assert_eq!(locator.to_string(), locator_str);
+    }
+
+    #[test_case(
+        None,
+        "pkg:composer/laravel/laravel@5.5.0",
+        "comp+laravel/laravel$5.5.0";
+        "no_fallback"
+    )]
+    #[test_case(
+        Some("vendor"),
+        "pkg:composer/laravel@5.5.0",
+        "comp+vendor/laravel$5.5.0";
+        "with_fallback"
+    )]
+    #[test_case(
+        Some("vendor"),
+        "pkg:composer/laravel/laravel@5.5.0",
+        "comp+laravel/laravel$5.5.0";
+        "unnecessary_fallback"
+    )]
+    #[test]
+    fn composer_options(fallback_namespace: Option<&str>, purl_str: &str, locator_str: &str) {
+        let purl = Purl::from_str(purl_str).expect("parse purl");
+        let options = ConversionOptions {
+            fallback_composer_namespace: fallback_namespace.map(String::from),
+            ..Default::default()
+        };
+        let locator = purl
+            .try_into_locator_with_options(options)
+            .expect("convert to locator");
+        assert_eq!(locator.to_string(), locator_str);
+    }
+
+    #[test_case(
+        "pkg:swift/Alamofire@5.4.3",
+        "Swift PURL requires a namespace";
+        "swift_missing_namespace"
+    )]
+    #[test_case(
+        "pkg:composer/laravel@5.5.0",
+        "Composer PURL requires a namespace (vendor name)";
+        "composer_missing_namespace"
+    )]
+    #[test_case(
+        "pkg:googlesource/edk2@aml_tz2_306503000",
+        "GoogleSource PURL must include a subdomain in the namespace";
+        "googlesource_missing_namespace"
+    )]
+    #[test]
+    fn missing_namespace_error(purl_str: &str, expected_msg: &str) {
+        let purl = Purl::from_str(purl_str).expect("parse purl");
+        let result = Locator::try_from(purl);
+        assert!(result.is_err());
+        match result {
+            Err(Error::MissingNamespace(msg)) => {
+                assert_eq!(msg, expected_msg);
+            }
+            _ => panic!("Expected MissingNamespace error, got: {result:?}"),
+        }
+    }
+
+    #[test_case(
+        "pkg:deb/ubuntu/adduser@3.118ubuntu2?arch=amd64",
+        "distro";
+        "deb_missing_distro"
+    )]
+    #[test]
+    fn missing_qualifier_error(purl_str: &str, expected_qualifier: &str) {
+        let purl = Purl::from_str(purl_str).expect("parse purl");
+        let result = Locator::try_from(purl);
+        assert!(result.is_err());
+        match result {
+            Err(Error::MissingQualifier(msg)) => {
+                assert_eq!(msg, expected_qualifier);
+            }
+            _ => panic!("Expected MissingQualifier error, got: {result:?}"),
+        }
+    }
+
+    #[test_case("pkg:foo/foo@1.0.0", "foo"; "unsupported")]
+    #[test]
+    fn unsupported_purl_error(purl_str: &str, expected_type: &str) {
+        let purl = Purl::from_str(purl_str).expect("parse purl");
+        let result = Locator::try_from(purl);
+        assert!(result.is_err());
+        match result {
+            Err(Error::UnsupportedPurl(msg)) => {
+                assert_eq!(msg, expected_type);
+            }
+            _ => panic!("Expected UnsupportedPurl error, got: {result:?}"),
+        }
+    }
+}

--- a/src/purl/apk.rs
+++ b/src/purl/apk.rs
@@ -1,4 +1,4 @@
-use crate::{Fetcher, Locator, Revision, purl::Purl};
+use crate::{Fetcher, Locator, purl::Purl};
 
 pub fn purl_to_locator(purl: Purl) -> Result<Locator, super::Error> {
     let package_name = [
@@ -22,6 +22,6 @@ pub fn purl_to_locator(purl: Purl) -> Result<Locator, super::Error> {
     Ok(Locator::builder()
         .fetcher(Fetcher::LinuxAlpine)
         .package(package_name)
-        .maybe_revision(Some(Revision::from(revision)))
+        .maybe_revision(super::revision(&revision))
         .build())
 }

--- a/src/purl/apk.rs
+++ b/src/purl/apk.rs
@@ -1,0 +1,27 @@
+use crate::{Fetcher, Locator, Revision, purl::Purl};
+
+pub fn purl_to_locator(purl: Purl) -> Result<Locator, super::Error> {
+    let package_name = [
+        Some(purl.name()),
+        purl.namespace(),
+        purl.qualifiers().get("distro"),
+    ]
+    .iter()
+    .flatten()
+    .cloned()
+    .collect::<Vec<_>>()
+    .join("#");
+
+    let revision = [purl.qualifiers().get("arch"), purl.version()]
+        .iter()
+        .flatten()
+        .cloned()
+        .collect::<Vec<_>>()
+        .join("#");
+
+    Ok(Locator::builder()
+        .fetcher(Fetcher::LinuxAlpine)
+        .package(package_name)
+        .maybe_revision(Some(Revision::from(revision)))
+        .build())
+}

--- a/src/purl/bitbucket.rs
+++ b/src/purl/bitbucket.rs
@@ -1,0 +1,19 @@
+use crate::{Fetcher, Locator, Revision, purl::Purl};
+
+pub const DOMAIN: &str = "bitbucket.org";
+
+pub fn purl_to_locator(purl: Purl) -> Result<Locator, super::Error> {
+    let package_name = [Some(DOMAIN), purl.namespace(), Some(purl.name())]
+        .iter()
+        .flatten()
+        .cloned()
+        .collect::<Vec<_>>()
+        .join("/");
+    let revision = purl.version().map(Revision::from);
+
+    Ok(Locator::builder()
+        .fetcher(Fetcher::Git)
+        .package(package_name)
+        .maybe_revision(revision)
+        .build())
+}

--- a/src/purl/bitbucket.rs
+++ b/src/purl/bitbucket.rs
@@ -1,4 +1,4 @@
-use crate::{Fetcher, Locator, Revision, purl::Purl};
+use crate::{Fetcher, Locator, purl::Purl};
 
 pub const DOMAIN: &str = "bitbucket.org";
 
@@ -9,7 +9,7 @@ pub fn purl_to_locator(purl: Purl) -> Result<Locator, super::Error> {
         .cloned()
         .collect::<Vec<_>>()
         .join("/");
-    let revision = purl.version().map(Revision::from);
+    let revision = purl.version().and_then(super::revision);
 
     Ok(Locator::builder()
         .fetcher(Fetcher::Git)

--- a/src/purl/cocoapods.rs
+++ b/src/purl/cocoapods.rs
@@ -1,4 +1,4 @@
-use crate::{Fetcher, Locator, Revision, purl::Purl};
+use crate::{Fetcher, Locator, purl::Purl};
 
 pub fn purl_to_locator(purl: Purl) -> Result<Locator, super::Error> {
     let package_parts = [Some(purl.name()), purl.subpath()];
@@ -9,7 +9,7 @@ pub fn purl_to_locator(purl: Purl) -> Result<Locator, super::Error> {
         .collect::<Vec<_>>()
         .join("/");
 
-    let revision = purl.version().map(Revision::from);
+    let revision = purl.version().and_then(super::revision);
 
     Ok(Locator::builder()
         .fetcher(Fetcher::Pod)

--- a/src/purl/cocoapods.rs
+++ b/src/purl/cocoapods.rs
@@ -1,0 +1,19 @@
+use crate::{Fetcher, Locator, Revision, purl::Purl};
+
+pub fn purl_to_locator(purl: Purl) -> Result<Locator, super::Error> {
+    let package_parts = [Some(purl.name()), purl.subpath()];
+    let package_name = package_parts
+        .iter()
+        .flatten()
+        .cloned()
+        .collect::<Vec<_>>()
+        .join("/");
+
+    let revision = purl.version().map(Revision::from);
+
+    Ok(Locator::builder()
+        .fetcher(Fetcher::Pod)
+        .package(package_name)
+        .maybe_revision(revision)
+        .build())
+}

--- a/src/purl/composer.rs
+++ b/src/purl/composer.rs
@@ -1,0 +1,24 @@
+use crate::{
+    Fetcher, Locator, Revision,
+    purl::{ConversionOptions, Purl},
+};
+
+pub fn purl_to_locator(purl: Purl, options: ConversionOptions) -> Result<Locator, super::Error> {
+    let namespace = purl
+        .namespace()
+        .or(options.fallback_composer_namespace.as_deref())
+        .ok_or_else(|| {
+            super::Error::MissingNamespace(
+                "Composer PURL requires a namespace (vendor name)".to_string(),
+            )
+        })?;
+
+    let package_name = format!("{}/{}", namespace, purl.name());
+    let revision = purl.version().map(Revision::from);
+
+    Ok(Locator::builder()
+        .fetcher(Fetcher::Comp)
+        .package(package_name)
+        .maybe_revision(revision)
+        .build())
+}

--- a/src/purl/composer.rs
+++ b/src/purl/composer.rs
@@ -1,5 +1,5 @@
 use crate::{
-    Fetcher, Locator, Revision,
+    Fetcher, Locator,
     purl::{ConversionOptions, Purl},
 };
 
@@ -14,7 +14,7 @@ pub fn purl_to_locator(purl: Purl, options: ConversionOptions) -> Result<Locator
         })?;
 
     let package_name = format!("{}/{}", namespace, purl.name());
-    let revision = purl.version().map(Revision::from);
+    let revision = purl.version().and_then(super::revision);
 
     Ok(Locator::builder()
         .fetcher(Fetcher::Comp)

--- a/src/purl/cpan.rs
+++ b/src/purl/cpan.rs
@@ -1,0 +1,16 @@
+use crate::{Fetcher, Locator, Revision, purl::Purl};
+
+pub fn purl_to_locator(purl: Purl) -> Result<Locator, super::Error> {
+    // CPAN locators use `::` as separator (e.g., `Tk::Tree`)
+    // while PURLs use `-` (e.g., `Tk-Tree`).
+    // The namespace is not used as multiple authors can maintain the same
+    // package over time.
+    let package_name = purl.name().replace('-', "::");
+    let revision = purl.version().map(Revision::from);
+
+    Ok(Locator::builder()
+        .fetcher(Fetcher::Cpan)
+        .package(package_name)
+        .maybe_revision(revision)
+        .build())
+}

--- a/src/purl/cpan.rs
+++ b/src/purl/cpan.rs
@@ -1,4 +1,4 @@
-use crate::{Fetcher, Locator, Revision, purl::Purl};
+use crate::{Fetcher, Locator, purl::Purl};
 
 pub fn purl_to_locator(purl: Purl) -> Result<Locator, super::Error> {
     // CPAN locators use `::` as separator (e.g., `Tk::Tree`)
@@ -6,7 +6,7 @@ pub fn purl_to_locator(purl: Purl) -> Result<Locator, super::Error> {
     // The namespace is not used as multiple authors can maintain the same
     // package over time.
     let package_name = purl.name().replace('-', "::");
-    let revision = purl.version().map(Revision::from);
+    let revision = purl.version().and_then(super::revision);
 
     Ok(Locator::builder()
         .fetcher(Fetcher::Cpan)

--- a/src/purl/deb.rs
+++ b/src/purl/deb.rs
@@ -1,0 +1,48 @@
+use crate::{
+    Fetcher, Locator, Revision,
+    purl::{ConversionOptions, Purl},
+};
+
+pub fn purl_to_locator(purl: Purl, options: ConversionOptions) -> Result<Locator, super::Error> {
+    let distro_name = purl
+        .namespace()
+        .or(options.fallback_deb_distro_name.as_deref())
+        .ok_or(super::Error::MissingQualifier("distro".to_string()))?;
+
+    // Most Debian purl examples use code names instead of the numeric versions
+    // (i.e., bullseye, buster, and stretch). On the other hand, Ubuntu uses
+    // numeric versions (i.e., ubuntu-20.04 and ubuntu-22.04).
+    let distro_version = purl
+        .qualifiers()
+        .get("distro")
+        .and_then(|distro| {
+            if distro.contains('-') {
+                distro.split('-').nth(1)
+            } else {
+                Some(distro)
+            }
+        })
+        .or(options.fallback_deb_distro_version.as_deref())
+        .ok_or(super::Error::MissingQualifier("distro".to_string()))?;
+
+    // Build package name: name#namespace#distro_version
+    let package_name = [purl.name(), distro_name, distro_version].join("#");
+
+    // Build revision: arch#version
+    let arch = purl
+        .qualifiers()
+        .get("arch")
+        .or(options.fallback_deb_arch.as_deref());
+    let revision = [arch, purl.version()]
+        .iter()
+        .flatten()
+        .cloned()
+        .collect::<Vec<_>>()
+        .join("#");
+
+    Ok(Locator::builder()
+        .fetcher(Fetcher::LinuxDebian)
+        .package(package_name)
+        .maybe_revision(Some(Revision::from(revision)))
+        .build())
+}

--- a/src/purl/deb.rs
+++ b/src/purl/deb.rs
@@ -1,5 +1,5 @@
 use crate::{
-    Fetcher, Locator, Revision,
+    Fetcher, Locator,
     purl::{ConversionOptions, Purl},
 };
 
@@ -43,6 +43,6 @@ pub fn purl_to_locator(purl: Purl, options: ConversionOptions) -> Result<Locator
     Ok(Locator::builder()
         .fetcher(Fetcher::LinuxDebian)
         .package(package_name)
-        .maybe_revision(Some(Revision::from(revision)))
+        .maybe_revision(super::revision(&revision))
         .build())
 }

--- a/src/purl/gitee.rs
+++ b/src/purl/gitee.rs
@@ -1,4 +1,4 @@
-use crate::{Fetcher, Locator, Revision, purl::Purl};
+use crate::{Fetcher, Locator, purl::Purl};
 
 pub const DOMAIN: &str = "gitee.com";
 
@@ -9,7 +9,7 @@ pub fn purl_to_locator(purl: Purl) -> Result<Locator, super::Error> {
         .cloned()
         .collect::<Vec<_>>()
         .join("/");
-    let revision = purl.version().map(Revision::from);
+    let revision = purl.version().and_then(super::revision);
 
     Ok(Locator::builder()
         .fetcher(Fetcher::Git)

--- a/src/purl/gitee.rs
+++ b/src/purl/gitee.rs
@@ -1,0 +1,19 @@
+use crate::{Fetcher, Locator, Revision, purl::Purl};
+
+pub const DOMAIN: &str = "gitee.com";
+
+pub fn purl_to_locator(purl: Purl) -> Result<Locator, super::Error> {
+    let package_name = [Some(DOMAIN), purl.namespace(), Some(purl.name())]
+        .iter()
+        .flatten()
+        .cloned()
+        .collect::<Vec<_>>()
+        .join("/");
+    let revision = purl.version().map(Revision::from);
+
+    Ok(Locator::builder()
+        .fetcher(Fetcher::Git)
+        .package(package_name)
+        .maybe_revision(revision)
+        .build())
+}

--- a/src/purl/github.rs
+++ b/src/purl/github.rs
@@ -1,0 +1,19 @@
+use crate::{Fetcher, Locator, Revision, purl::Purl};
+
+pub const DOMAIN: &str = "github.com";
+
+pub fn purl_to_locator(purl: Purl) -> Result<Locator, super::Error> {
+    let package_name = [Some(DOMAIN), purl.namespace(), Some(purl.name())]
+        .iter()
+        .flatten()
+        .cloned()
+        .collect::<Vec<_>>()
+        .join("/");
+    let revision = purl.version().map(Revision::from);
+
+    Ok(Locator::builder()
+        .fetcher(Fetcher::Git)
+        .package(package_name)
+        .maybe_revision(revision)
+        .build())
+}

--- a/src/purl/github.rs
+++ b/src/purl/github.rs
@@ -1,4 +1,4 @@
-use crate::{Fetcher, Locator, Revision, purl::Purl};
+use crate::{Fetcher, Locator, purl::Purl};
 
 pub const DOMAIN: &str = "github.com";
 
@@ -9,7 +9,7 @@ pub fn purl_to_locator(purl: Purl) -> Result<Locator, super::Error> {
         .cloned()
         .collect::<Vec<_>>()
         .join("/");
-    let revision = purl.version().map(Revision::from);
+    let revision = purl.version().and_then(super::revision);
 
     Ok(Locator::builder()
         .fetcher(Fetcher::Git)

--- a/src/purl/gitlab.rs
+++ b/src/purl/gitlab.rs
@@ -1,0 +1,19 @@
+use crate::{Fetcher, Locator, Revision, purl::Purl};
+
+pub const DOMAIN: &str = "gitlab.com";
+
+pub fn purl_to_locator(purl: Purl) -> Result<Locator, super::Error> {
+    let package_name = [Some(DOMAIN), purl.namespace(), Some(purl.name())]
+        .iter()
+        .flatten()
+        .cloned()
+        .collect::<Vec<_>>()
+        .join("/");
+    let revision = purl.version().map(Revision::from);
+
+    Ok(Locator::builder()
+        .fetcher(Fetcher::Git)
+        .package(package_name)
+        .maybe_revision(revision)
+        .build())
+}

--- a/src/purl/gitlab.rs
+++ b/src/purl/gitlab.rs
@@ -1,4 +1,4 @@
-use crate::{Fetcher, Locator, Revision, purl::Purl};
+use crate::{Fetcher, Locator, purl::Purl};
 
 pub const DOMAIN: &str = "gitlab.com";
 
@@ -9,7 +9,7 @@ pub fn purl_to_locator(purl: Purl) -> Result<Locator, super::Error> {
         .cloned()
         .collect::<Vec<_>>()
         .join("/");
-    let revision = purl.version().map(Revision::from);
+    let revision = purl.version().and_then(super::revision);
 
     Ok(Locator::builder()
         .fetcher(Fetcher::Git)

--- a/src/purl/golang.rs
+++ b/src/purl/golang.rs
@@ -1,0 +1,19 @@
+use crate::{Fetcher, Locator, Revision, purl::Purl};
+
+pub fn purl_to_locator(purl: Purl) -> Result<Locator, super::Error> {
+    let package_parts = [purl.namespace(), Some(purl.name()), purl.subpath()];
+    let package_name = package_parts
+        .iter()
+        .flatten()
+        .cloned()
+        .collect::<Vec<_>>()
+        .join("/");
+
+    let revision = purl.version().map(Revision::from);
+
+    Ok(Locator::builder()
+        .fetcher(Fetcher::Go)
+        .package(package_name)
+        .maybe_revision(revision)
+        .build())
+}

--- a/src/purl/golang.rs
+++ b/src/purl/golang.rs
@@ -1,4 +1,4 @@
-use crate::{Fetcher, Locator, Revision, purl::Purl};
+use crate::{Fetcher, Locator, purl::Purl};
 
 pub fn purl_to_locator(purl: Purl) -> Result<Locator, super::Error> {
     let package_parts = [purl.namespace(), Some(purl.name()), purl.subpath()];
@@ -9,7 +9,7 @@ pub fn purl_to_locator(purl: Purl) -> Result<Locator, super::Error> {
         .collect::<Vec<_>>()
         .join("/");
 
-    let revision = purl.version().map(Revision::from);
+    let revision = purl.version().and_then(super::revision);
 
     Ok(Locator::builder()
         .fetcher(Fetcher::Go)

--- a/src/purl/googlesource.rs
+++ b/src/purl/googlesource.rs
@@ -1,0 +1,33 @@
+use crate::{Fetcher, Locator, Revision, purl::Purl};
+
+pub const DOMAIN: &str = "googlesource.com";
+
+pub fn purl_to_locator(purl: Purl) -> Result<Locator, super::Error> {
+    // GoogleSource PURLs have the subdomain as the first part of namespace.
+    // e.g., pkg:googlesource/android/device/linaro/bootloader/edk2
+    // becomes android.googlesource.com/device/linaro/bootloader/edk2
+    let namespace_parts = purl
+        .namespace()
+        .map(|ns| ns.split('/').collect::<Vec<_>>())
+        .unwrap_or_default();
+
+    let subdomain = namespace_parts.first().ok_or_else(|| {
+        super::Error::MissingNamespace(
+            "GoogleSource PURL must include a subdomain in the namespace".to_string(),
+        )
+    })?;
+    let remaining_namespace = &namespace_parts[1..];
+
+    let mut package_parts = vec![format!("{}.{}", subdomain, DOMAIN)];
+    package_parts.extend(remaining_namespace.iter().map(|s| s.to_string()));
+    package_parts.push(purl.name().to_string());
+
+    let package_name = package_parts.join("/");
+    let revision = purl.version().map(Revision::from);
+
+    Ok(Locator::builder()
+        .fetcher(Fetcher::Git)
+        .package(package_name)
+        .maybe_revision(revision)
+        .build())
+}

--- a/src/purl/googlesource.rs
+++ b/src/purl/googlesource.rs
@@ -1,4 +1,4 @@
-use crate::{Fetcher, Locator, Revision, purl::Purl};
+use crate::{Fetcher, Locator, purl::Purl};
 
 pub const DOMAIN: &str = "googlesource.com";
 
@@ -23,7 +23,7 @@ pub fn purl_to_locator(purl: Purl) -> Result<Locator, super::Error> {
     package_parts.push(purl.name().to_string());
 
     let package_name = package_parts.join("/");
-    let revision = purl.version().map(Revision::from);
+    let revision = purl.version().and_then(super::revision);
 
     Ok(Locator::builder()
         .fetcher(Fetcher::Git)

--- a/src/purl/maven.rs
+++ b/src/purl/maven.rs
@@ -1,0 +1,25 @@
+use crate::{Fetcher, Locator, Revision, purl::Purl};
+
+pub fn purl_to_locator(purl: Purl) -> Result<Locator, super::Error> {
+    let mut package_parts = Vec::new();
+
+    // If repository_url qualifier exists, include it first
+    if let Some(repository_url) = purl.qualifiers().get("repository_url") {
+        package_parts.push(repository_url);
+    }
+
+    // Always include namespace and name
+    if let Some(namespace) = purl.namespace() {
+        package_parts.push(namespace);
+    }
+    package_parts.push(purl.name());
+
+    let package_name = package_parts.join(":");
+    let revision = purl.version().map(Revision::from);
+
+    Ok(Locator::builder()
+        .fetcher(Fetcher::Maven)
+        .package(package_name)
+        .maybe_revision(revision)
+        .build())
+}

--- a/src/purl/maven.rs
+++ b/src/purl/maven.rs
@@ -1,4 +1,4 @@
-use crate::{Fetcher, Locator, Revision, purl::Purl};
+use crate::{Fetcher, Locator, purl::Purl};
 
 pub fn purl_to_locator(purl: Purl) -> Result<Locator, super::Error> {
     let mut package_parts = Vec::new();
@@ -15,7 +15,7 @@ pub fn purl_to_locator(purl: Purl) -> Result<Locator, super::Error> {
     package_parts.push(purl.name());
 
     let package_name = package_parts.join(":");
-    let revision = purl.version().map(Revision::from);
+    let revision = purl.version().and_then(super::revision);
 
     Ok(Locator::builder()
         .fetcher(Fetcher::Maven)

--- a/src/purl/npm.rs
+++ b/src/purl/npm.rs
@@ -1,4 +1,4 @@
-use crate::{Fetcher, Locator, Revision, purl::Purl};
+use crate::{Fetcher, Locator, purl::Purl};
 
 pub fn purl_to_locator(purl: Purl) -> Result<Locator, super::Error> {
     let package_name = if let Some(namespace) = purl.namespace() {
@@ -7,7 +7,7 @@ pub fn purl_to_locator(purl: Purl) -> Result<Locator, super::Error> {
         purl.name().to_string()
     };
 
-    let revision = purl.version().map(Revision::from);
+    let revision = purl.version().and_then(super::revision);
 
     Ok(Locator::builder()
         .fetcher(Fetcher::Npm)

--- a/src/purl/npm.rs
+++ b/src/purl/npm.rs
@@ -1,0 +1,17 @@
+use crate::{Fetcher, Locator, Revision, purl::Purl};
+
+pub fn purl_to_locator(purl: Purl) -> Result<Locator, super::Error> {
+    let package_name = if let Some(namespace) = purl.namespace() {
+        format!("{}/{}", namespace, purl.name())
+    } else {
+        purl.name().to_string()
+    };
+
+    let revision = purl.version().map(Revision::from);
+
+    Ok(Locator::builder()
+        .fetcher(Fetcher::Npm)
+        .package(package_name)
+        .maybe_revision(revision)
+        .build())
+}

--- a/src/purl/rpm.rs
+++ b/src/purl/rpm.rs
@@ -1,0 +1,39 @@
+use crate::{Fetcher, Locator, Revision, purl::Purl};
+
+pub fn purl_to_locator(purl: Purl) -> Result<Locator, super::Error> {
+    // Distro examples: fedora-25 and centos-7.6.1810
+    // Use 'latest' when distro version is unavailable to prevent API fail.
+    let distro_version = purl
+        .qualifiers()
+        .get("distro")
+        .and_then(|distro| distro.split('-').nth(1))
+        .unwrap_or("latest");
+
+    // Build package name: name#namespace#distro_version
+    let package_name = [Some(purl.name()), purl.namespace(), Some(distro_version)]
+        .iter()
+        .flatten()
+        .cloned()
+        .collect::<Vec<_>>()
+        .join("#");
+
+    // Build revision: arch#epoch:version
+    let version_with_epoch = purl.version().map(|v| {
+        let epoch = purl.qualifiers().get("epoch").unwrap_or("0");
+        format!("{epoch}:{v}")
+    });
+
+    let revision_parts = [purl.qualifiers().get("arch"), version_with_epoch.as_deref()];
+    let revision = revision_parts
+        .iter()
+        .flatten()
+        .cloned()
+        .collect::<Vec<_>>()
+        .join("#");
+
+    Ok(Locator::builder()
+        .fetcher(Fetcher::LinuxRpm)
+        .package(package_name)
+        .maybe_revision(Some(Revision::from(revision)))
+        .build())
+}

--- a/src/purl/rpm.rs
+++ b/src/purl/rpm.rs
@@ -1,4 +1,4 @@
-use crate::{Fetcher, Locator, Revision, purl::Purl};
+use crate::{Fetcher, Locator, purl::Purl};
 
 pub fn purl_to_locator(purl: Purl) -> Result<Locator, super::Error> {
     // Distro examples: fedora-25 and centos-7.6.1810
@@ -34,6 +34,6 @@ pub fn purl_to_locator(purl: Purl) -> Result<Locator, super::Error> {
     Ok(Locator::builder()
         .fetcher(Fetcher::LinuxRpm)
         .package(package_name)
-        .maybe_revision(Some(Revision::from(revision)))
+        .maybe_revision(super::revision(&revision))
         .build())
 }

--- a/src/purl/sourceforge.rs
+++ b/src/purl/sourceforge.rs
@@ -1,4 +1,4 @@
-use crate::{Fetcher, Locator, Revision, purl::Purl};
+use crate::{Fetcher, Locator, purl::Purl};
 
 pub fn purl_to_locator(purl: Purl) -> Result<Locator, super::Error> {
     // SourceForge PURLs can be:
@@ -7,7 +7,7 @@ pub fn purl_to_locator(purl: Purl) -> Result<Locator, super::Error> {
     // pkg:sourceforge/pkgname/subpkgname@1.0
     // if there is no subpkgname, then the namespace will be the name.
     let package_name = purl.namespace().unwrap_or(purl.name());
-    let revision = purl.version().map(Revision::from);
+    let revision = purl.version().and_then(super::revision);
 
     Ok(Locator::builder()
         .fetcher(Fetcher::SourceForge)

--- a/src/purl/sourceforge.rs
+++ b/src/purl/sourceforge.rs
@@ -1,0 +1,17 @@
+use crate::{Fetcher, Locator, Revision, purl::Purl};
+
+pub fn purl_to_locator(purl: Purl) -> Result<Locator, super::Error> {
+    // SourceForge PURLs can be:
+    // pkg:sourceforge/pkgname@1.0
+    // or
+    // pkg:sourceforge/pkgname/subpkgname@1.0
+    // if there is no subpkgname, then the namespace will be the name.
+    let package_name = purl.namespace().unwrap_or(purl.name());
+    let revision = purl.version().map(Revision::from);
+
+    Ok(Locator::builder()
+        .fetcher(Fetcher::SourceForge)
+        .package(package_name)
+        .maybe_revision(revision)
+        .build())
+}

--- a/src/purl/swift.rs
+++ b/src/purl/swift.rs
@@ -1,0 +1,22 @@
+use crate::{
+    Fetcher, Locator, Revision,
+    purl::{ConversionOptions, Purl},
+};
+
+pub fn purl_to_locator(purl: Purl, options: ConversionOptions) -> Result<Locator, super::Error> {
+    let namespace = purl
+        .namespace()
+        .or(options.fallback_swift_namespace.as_deref())
+        .ok_or_else(|| {
+            super::Error::MissingNamespace("Swift PURL requires a namespace".to_string())
+        })?;
+
+    let package_name = format!("{}/{}", namespace, purl.name());
+    let revision = purl.version().map(Revision::from);
+
+    Ok(Locator::builder()
+        .fetcher(Fetcher::Swift)
+        .package(package_name)
+        .maybe_revision(revision)
+        .build())
+}

--- a/src/purl/swift.rs
+++ b/src/purl/swift.rs
@@ -1,5 +1,5 @@
 use crate::{
-    Fetcher, Locator, Revision,
+    Fetcher, Locator,
     purl::{ConversionOptions, Purl},
 };
 
@@ -12,7 +12,7 @@ pub fn purl_to_locator(purl: Purl, options: ConversionOptions) -> Result<Locator
         })?;
 
     let package_name = format!("{}/{}", namespace, purl.name());
-    let revision = purl.version().map(Revision::from);
+    let revision = purl.version().and_then(super::revision);
 
     Ok(Locator::builder()
         .fetcher(Fetcher::Swift)

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -9,6 +9,10 @@ fn fetcher_serde_names_match_locator_names() {
     for fetcher in locator::Fetcher::iter() {
         let json = serde_json::to_value(fetcher).expect("serialize fetcher");
         let name = json.as_str().expect("fetcher serializes to a string");
-        assert_eq!(name, fetcher.to_string(), "serde/strum name mismatch for {fetcher:?}");
+        assert_eq!(
+            name,
+            fetcher.to_string(),
+            "serde/strum name mismatch for {fetcher:?}"
+        );
     }
 }

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -1,1 +1,14 @@
 mod constraint;
+
+/// The JSON name of every fetcher must match its locator-string name.
+/// Consumers treat these as interchangeable (e.g. the `mvn` fetcher must not
+/// serialize as `maven`); `#[serde(alias = ...)]` keeps old spellings parseable.
+#[test]
+fn fetcher_serde_names_match_locator_names() {
+    use strum::IntoEnumIterator;
+    for fetcher in locator::Fetcher::iter() {
+        let json = serde_json::to_value(fetcher).expect("serialize fetcher");
+        let name = json.as_str().expect("fetcher serializes to a string");
+        assert_eq!(name, fetcher.to_string(), "serde/strum name mismatch for {fetcher:?}");
+    }
+}


### PR DESCRIPTION
# Overview

This PR backports the purl module (PURL → `Locator` conversion) from the v4 line to v3. The v4 line is being retired: its only active consumer is ficus, and purl conversion (#36) is the only v4-specific functionality ficus uses. This backport is the last piece ficus needs to migrate (fossas/ficus#180), after which nothing depends on v4.

This releases as **v5.0.0** on `main`. It's purely additive over v3, but backwards-incompatible with v4, so we'll bump the main version to v5.

This is a direct copy of v4's `locator/src/purl.rs` and its 16 ecosystem submodules, with `Ecosystem` renamed to `Fetcher` (v3's name for the same concept):

- Each submodule differs from the version on v4 by 3 lines: the import, the builder call, and the revision line (below).
- `purl.rs`: `ecosystem()` is renamed `fetcher()` with a one-to-one variant mapping, plus the shared `revision` helper and its regression tests.
- The v4 purl test suite is ported along with the code.

You can see that in this diff:

```sh
git fetch origin v4-maintenance purl-to-v3
diff <(git show origin/v4-maintenance:locator/src/purl.rs) <(git show origin/purl-to-v3:src/purl.rs)
```

Almost all of the changes are renaming Ecosystem -> Fetcher.

There is one largish behaviour change. v4 builds revisions with a fallible parse that returns `None` for empty input. v3 has no fallible parse, and its infallible `Revision::from` would instead produce `Some(Opaque(""))`.

For example, `pkg:apk/alpine/curl` has no version and no `arch` qualifier, so the apk/deb/rpm revision (built by joining whichever of `arch`/`version` are present with `#`) comes out as the empty string:

```text
pkg:apk/alpine/curl  →  apk+curl#alpine   (v4, Core, and this PR)
                     →  apk+curl#alpine$  (naive port: trailing $, doesn't round-trip through Locator::parse)
```

A purl whose version is only whitespace (`pkg:npm/foobar@%20`, version = `" "`) has the same problem.

To handle this, every conversion routes through one shared helper — `revision()` in `src/purl.rs` — which trims and maps empty to `None`, reproducing v4's observable behaviour. This also matches Core, whose `Locator` class coerces an empty revision to null. 

## Risks

**`v`-prefixed revisions** This is a pre-existing difference between the v3 and v4 branches. v4 strips a leading `v` before comparing revisions, so `v1.2.3 == 1.2.3`. v3 classifies `v1.2.3` as `Opaque`, which never equals `Semver(1.2.3)` — v3 equality is effectively string equality for v-prefixed versions.

Rendered locator strings are identical on both branches; the difference is only observable in in-memory comparison (`Eq`/`Ord`/`Hash`). For example, these two locators are the *same* key in a v4 `HashMap<Locator, _>` but *different* keys in v3:

```text
git+github.com/foo/bar$v1.2.3
git+github.com/foo/bar$1.2.3
```

This stays as-is, for two reasons: v3's string-equality semantics match how Core compares locators, and `v`-stripping is unsafe exactly where prefixes occur — for git and go, `v2` and `2` can be different refs. Consumers migrating off v4 inherit strict string equality.

## Fetcher JSON names

Equivalence testing caught `Maven`/`SourceForge`/`StackOverflow` serializing to JSON as their snake_case variant names (`"maven"`, `"source_forge"`, `"stack_overflow"`) instead of their locator-string names (`"mvn"`, `"sourceforge"`, `"stackoverflow"`). They had `#[serde(alias)]` — which only affects deserialization — where they needed `rename`.

This PR renames them. The old spellings remain as deserialization aliases so existing payloads still parse, and a regression test pins every `Fetcher`'s serde name to its strum name.

This is a safe change because Sparkle never serializes a `Fetcher` and already parses both spellings; ficus's serialized output becomes identical to what it emits on v4 today.

## Testing plan

To test, run against something that Vendetta finds vendored deps in. I used the deps directory of github.com/redis/redis. The test passes if the v3 and v4 versions give the same result.

```bash
export FOSSA_API_TOKEN=<token>
cd ~/fossa/ficus
git checkout main && cargo build --release && cp target/release/ficus /tmp/ficus-v4
git checkout scott/locator-purl-to-v3 && cargo build --release && cp target/release/ficus /tmp/ficus-v3

git clone --depth 1 https://github.com/redis/redis /tmp/redis && cd /tmp/redis/deps

/tmp/ficus-v4 analyze --strategy vendetta --locator 'custom+equiv-test$v4' > /tmp/v4.ndjson 2> /tmp/v4.log
/tmp/ficus-v3 analyze --strategy vendetta --locator 'custom+equiv-test$v3' > /tmp/v3.ndjson 2> /tmp/v3.log

jq -c 'select(.observation.strategy=="vendetta" and .observation.kind=="finding") | .observation.payload' /tmp/v4.ndjson | sort > /tmp/v4-findings.txt
jq -c 'select(.observation.strategy=="vendetta" and .observation.kind=="finding") | .observation.payload' /tmp/v3.ndjson | sort > /tmp/v3-findings.txt
```

There should be no difference between the results for v4 and v3, so /tmp/v4-findings.txt and /tmp/v3-findings.txt should be exactly the same.

## Metrics

Not applicable — this is a library change with no runtime surface of its own; consumers pin tags.

## References

- #36: original purl support on the v4 line
- fossas/ficus#180: the ficus migration that consumes this backport
- Ficus's usage of this API: `ficus/src/strategy/vendetta/solver.rs` (`parse_locator`)

## Checklist

- [x] I added tests for this PR's change (the v4 purl test suite is ported alongside the module).



